### PR TITLE
New release 0.1.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,10 @@
+# Changelog
+## [0.1.1] - 2023-01-28
+### Breaking changes
+ - N/A
+
+### New features
+ - N/A
+
+### Bug fixes
+ - Use latest rust-netlink crates. (a5f55b5)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # The crate name `nl80211` is occupied
 name = "wl-nl80211"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "MIT"
 edition = "2018"


### PR DESCRIPTION
=== Breaking changes
 - N/A

=== New features
 - N/A

=== Bug fixes
 - Use latest rust-netlink crates. (a5f55b5)