### PR TITLE
Add station get command

### DIFF
--- a/examples/dump_nl80211_station.rs
+++ b/examples/dump_nl80211_station.rs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+
+use std::env::args;
+
+use anyhow::{bail, Context, Error};
+use futures::stream::TryStreamExt;
+
+fn main() -> Result<(), Error> {
+    let argv: Vec<_> = args().collect();
+
+    if argv.len() < 2 {
+        eprintln!("Usage: dump_nl80211_station <interface index>");
+        bail!("Required arguments not given");
+    }
+
+    let err_msg = format!("Invalid interface index value: {}", argv[1]);
+    let index = argv[1].parse::<u32>().context(err_msg)?;
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .build()
+        .unwrap();
+    rt.block_on(dump_station(index));
+
+    Ok(())
+}
+
+async fn dump_station(if_index: u32) {
+    let (connection, handle, _) = wl_nl80211::new_connection().unwrap();
+    tokio::spawn(connection);
+
+    let mut sta_handle = handle.station().dump(if_index).execute().await;
+
+    let mut msgs = Vec::new();
+    while let Some(msg) = sta_handle.try_next().await.unwrap() {
+        msgs.push(msg);
+    }
+    assert!(!msgs.is_empty());
+    for msg in msgs {
+        println!("{:?}", msg);
+    }
+}

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -8,6 +8,7 @@ use netlink_packet_utils::DecodeError;
 
 use crate::{
     try_nl80211, Nl80211Error, Nl80211InterfaceHandle, Nl80211Message,
+    Nl80211StationHandle,
 };
 
 #[derive(Clone, Debug)]
@@ -23,6 +24,11 @@ impl Nl80211Handle {
     // equivalent to `iw dev` command
     pub fn interface(&self) -> Nl80211InterfaceHandle {
         Nl80211InterfaceHandle::new(self.clone())
+    }
+
+    // equivalent to `iw dev DEVICE station` command
+    pub fn station(&self) -> Nl80211StationHandle {
+        Nl80211StationHandle::new(self.clone())
     }
 
     pub async fn request(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub use iface::{
 };
 pub use message::{Nl80211Cmd, Nl80211Message};
 pub use station::{
-    Nl80211StationInfo,
+    Nl80211StationGetRequest, Nl80211StationHandle, Nl80211StationInfo,
 };
 pub use stats::{
     NestedNl80211TidStats, Nl80211TidStats, Nl80211TransmitQueueStat,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,8 @@ pub use iface::{
     Nl80211InterfaceGetRequest, Nl80211InterfaceHandle, Nl80211InterfaceType,
 };
 pub use message::{Nl80211Cmd, Nl80211Message};
-pub use stats::Nl80211TransmitQueueStat;
+pub use stats::{
+    NestedNl80211TidStats, Nl80211TidStats, Nl80211TransmitQueueStat,
+};
 
 pub(crate) use handle::nl80211_execute;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,10 +8,11 @@ mod handle;
 mod iface;
 mod macros;
 mod message;
+mod station;
 mod stats;
 
 pub use attr::Nl80211Attr;
-pub use channel::Nl80211WiPhyChannelType;
+pub use channel::{Nl80211ChannelWidth, Nl80211WiPhyChannelType};
 #[cfg(feature = "tokio_socket")]
 pub use connection::new_connection;
 pub use connection::new_connection_with_socket;
@@ -21,6 +22,9 @@ pub use iface::{
     Nl80211InterfaceGetRequest, Nl80211InterfaceHandle, Nl80211InterfaceType,
 };
 pub use message::{Nl80211Cmd, Nl80211Message};
+pub use station::{
+    Nl80211StationInfo,
+};
 pub use stats::{
     NestedNl80211TidStats, Nl80211TidStats, Nl80211TransmitQueueStat,
 };

--- a/src/message.rs
+++ b/src/message.rs
@@ -10,11 +10,15 @@ use crate::attr::Nl80211Attr;
 
 const NL80211_CMD_GET_INTERFACE: u8 = 5;
 const NL80211_CMD_NEW_INTERFACE: u8 = 7;
+const NL80211_CMD_GET_STATION: u8 = 17;
+const NL80211_CMD_NEW_STATION: u8 = 19;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Nl80211Cmd {
     InterfaceGet,
     InterfaceNew,
+    StationGet,
+    StationNew,
 }
 
 impl From<Nl80211Cmd> for u8 {
@@ -22,6 +26,8 @@ impl From<Nl80211Cmd> for u8 {
         match cmd {
             Nl80211Cmd::InterfaceGet => NL80211_CMD_GET_INTERFACE,
             Nl80211Cmd::InterfaceNew => NL80211_CMD_NEW_INTERFACE,
+            Nl80211Cmd::StationGet => NL80211_CMD_GET_STATION,
+            Nl80211Cmd::StationNew => NL80211_CMD_NEW_STATION,
         }
     }
 }
@@ -51,6 +57,13 @@ impl Nl80211Message {
         Nl80211Message {
             cmd: Nl80211Cmd::InterfaceGet,
             nlas: vec![],
+        }
+    }
+
+    pub fn new_station_get(nlas: Vec<Nl80211Attr>) -> Self {
+        Nl80211Message {
+            cmd: Nl80211Cmd::StationGet,
+            nlas,
         }
     }
 }
@@ -84,6 +97,14 @@ impl ParseableParametrized<[u8], GenlHeader> for Nl80211Message {
         Ok(match header.cmd {
             NL80211_CMD_NEW_INTERFACE => Self {
                 cmd: Nl80211Cmd::InterfaceNew,
+                nlas: parse_nlas(buffer)?,
+            },
+            NL80211_CMD_GET_STATION => Self {
+                cmd: Nl80211Cmd::StationGet,
+                nlas: parse_nlas(buffer)?,
+            },
+            NL80211_CMD_NEW_STATION => Self {
+                cmd: Nl80211Cmd::StationNew,
                 nlas: parse_nlas(buffer)?,
             },
             cmd => {

--- a/src/station/get.rs
+++ b/src/station/get.rs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+
+use futures::TryStream;
+use netlink_packet_generic::GenlMessage;
+
+use crate::{
+    nl80211_execute, Nl80211Attr, Nl80211Error, Nl80211Handle, Nl80211Message,
+};
+
+const ETH_ALEN: usize = 6;
+
+pub struct Nl80211StationGetRequest {
+    handle: Nl80211Handle,
+    if_index: u32,
+    mac_address: Option<[u8; ETH_ALEN]>,
+}
+
+impl Nl80211StationGetRequest {
+    pub(crate) fn new(
+        handle: Nl80211Handle,
+        if_index: u32,
+        mac_address: Option<[u8; ETH_ALEN]>,
+    ) -> Self {
+        Nl80211StationGetRequest {
+            handle,
+            if_index,
+            mac_address,
+        }
+    }
+
+    pub async fn execute(
+        self,
+    ) -> impl TryStream<Ok = GenlMessage<Nl80211Message>, Error = Nl80211Error>
+    {
+        let Nl80211StationGetRequest {
+            mut handle,
+            if_index,
+            mac_address,
+        } = self;
+
+        let mut nlas = vec![Nl80211Attr::IfIndex(if_index)];
+        if let Some(arr) = mac_address {
+            nlas.push(Nl80211Attr::Mac(arr))
+        }
+
+        let nl80211_msg = Nl80211Message::new_station_get(nlas);
+
+        nl80211_execute(&mut handle, nl80211_msg).await
+    }
+}

--- a/src/station/handle.rs
+++ b/src/station/handle.rs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+
+use crate::{Nl80211Handle, Nl80211StationGetRequest};
+
+pub struct Nl80211StationHandle(Nl80211Handle);
+
+impl Nl80211StationHandle {
+    pub fn new(handle: Nl80211Handle) -> Self {
+        Nl80211StationHandle(handle)
+    }
+
+    /// Retrieve the stations
+    /// (equivalent to `iw dev DEV station dump`)
+    pub fn dump(&mut self, if_index: u32) -> Nl80211StationGetRequest {
+        Nl80211StationGetRequest::new(self.0.clone(), if_index, None)
+    }
+}

--- a/src/station/mod.rs
+++ b/src/station/mod.rs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+mod rate_info;
+mod station_info;
+
+pub use rate_info::Nl80211RateInfo;
+pub use station_info::Nl80211StationInfo;

--- a/src/station/mod.rs
+++ b/src/station/mod.rs
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: MIT
 
+mod get;
+mod handle;
 mod rate_info;
 mod station_info;
 
+pub use get::Nl80211StationGetRequest;
+pub use handle::Nl80211StationHandle;
 pub use rate_info::Nl80211RateInfo;
 pub use station_info::Nl80211StationInfo;

--- a/src/station/rate_info.rs
+++ b/src/station/rate_info.rs
@@ -1,0 +1,572 @@
+// SPDX-License-Identifier: MIT
+
+use anyhow::Context;
+use byteorder::{ByteOrder, NativeEndian};
+use netlink_packet_utils::{
+    nla::{DefaultNla, Nla, NlaBuffer},
+    parsers::{parse_u16, parse_u32, parse_u8},
+    DecodeError, Emitable, Parseable,
+};
+
+pub const NL80211_RATE_INFO_BITRATE: u16 = 1;
+pub const NL80211_RATE_INFO_MCS: u16 = 2;
+pub const NL80211_RATE_INFO_40_MHZ_WIDTH: u16 = 3;
+pub const NL80211_RATE_INFO_SHORT_GI: u16 = 4;
+pub const NL80211_RATE_INFO_BITRATE32: u16 = 5;
+pub const NL80211_RATE_INFO_VHT_MCS: u16 = 6;
+pub const NL80211_RATE_INFO_VHT_NSS: u16 = 7;
+pub const NL80211_RATE_INFO_80_MHZ_WIDTH: u16 = 8;
+pub const NL80211_RATE_INFO_80P80_MHZ_WIDTH: u16 = 9;
+pub const NL80211_RATE_INFO_160_MHZ_WIDTH: u16 = 10;
+pub const NL80211_RATE_INFO_10_MHZ_WIDTH: u16 = 11;
+pub const NL80211_RATE_INFO_5_MHZ_WIDTH: u16 = 12;
+pub const NL80211_RATE_INFO_HE_MCS: u16 = 13;
+pub const NL80211_RATE_INFO_HE_NSS: u16 = 14;
+pub const NL80211_RATE_INFO_HE_GI: u16 = 15;
+pub const NL80211_RATE_INFO_HE_DCM: u16 = 16;
+pub const NL80211_RATE_INFO_HE_RU_ALLOC: u16 = 17;
+pub const NL80211_RATE_INFO_320_MHZ_WIDTH: u16 = 18;
+pub const NL80211_RATE_INFO_EHT_MCS: u16 = 19;
+pub const NL80211_RATE_INFO_EHT_NSS: u16 = 20;
+pub const NL80211_RATE_INFO_EHT_GI: u16 = 21;
+pub const NL80211_RATE_INFO_EHT_RU_ALLOC: u16 = 22;
+pub const NL80211_RATE_INFO_S1G_MCS: u16 = 23;
+pub const NL80211_RATE_INFO_S1G_NSS: u16 = 24;
+pub const NL80211_RATE_INFO_1_MHZ_WIDTH: u16 = 25;
+pub const NL80211_RATE_INFO_2_MHZ_WIDTH: u16 = 26;
+pub const NL80211_RATE_INFO_4_MHZ_WIDTH: u16 = 27;
+pub const NL80211_RATE_INFO_8_MHZ_WIDTH: u16 = 28;
+pub const NL80211_RATE_INFO_16_MHZ_WIDTH: u16 = 29;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum Nl80211RateInfo {
+    /// Total bitrate, 100kb/s
+    Bitrate(u16),
+    /// MCS index for 802.11n
+    Mcs(u8),
+    MhzWidth(u32),
+    /// 400ns guard interval
+    ShortGi,
+    /// Total bitrate, 100kb/s
+    Bitrate32(u32),
+    /// MCS index for VHT
+    VhtMcs(u8),
+    /// Number of streams in VHT
+    VhtNss(u8),
+    /// Unused, 80+80 is treated the same as 160 for purposes of the bitrates
+    MhzWidth80Plus80,
+    /// HE MCS index
+    HeMcs(u8),
+    /// HE NSS value
+    HeNss(u8),
+    /// HE guard interval identifier [`Nl80211HeGi`]
+    HeGi(Nl80211HeGi),
+    /// HE DCM value
+    HeDcm(u8),
+    /// HE RU allocation, if not present then non-OFDMA was used.
+    /// See [`Nl80211HeRuAlloc`]
+    HeRuAlloc(Nl80211HeRuAllocation),
+    /// S1G MCS index
+    S1gMcs(u8),
+    /// S1G NSS value
+    S1gNss(u8),
+    /// EHT MCS index
+    EhtMcs(u8),
+    /// EHT NSS value
+    EhtNss(u8),
+    /// EHT guard interval identifier [`Nl80211EhtGi`]
+    EhtGi(Nl80211EhtGi),
+    /// EHT RU allocation, if not present then non-OFDMA was used.
+    /// See [`Nl80211EhtRuAlloc`]
+    EhtRuAlloc(Nl80211EhtRuAllocation),
+
+    Other(DefaultNla),
+}
+
+impl Nla for Nl80211RateInfo {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::MhzWidth(_) | Self::ShortGi | Self::MhzWidth80Plus80 => 0,
+            Self::Mcs(_)
+            | Self::VhtMcs(_)
+            | Self::VhtNss(_)
+            | Self::HeMcs(_)
+            | Self::HeNss(_)
+            | Self::HeGi(_)
+            | Self::HeDcm(_)
+            | Self::HeRuAlloc(_)
+            | Self::S1gMcs(_)
+            | Self::S1gNss(_)
+            | Self::EhtMcs(_)
+            | Self::EhtNss(_)
+            | Self::EhtGi(_)
+            | Self::EhtRuAlloc(_) => 1,
+            Self::Bitrate(_) => 2,
+            Self::Bitrate32(_) => 4,
+            Self::Other(ref nlas) => nlas.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::Bitrate(_) => NL80211_RATE_INFO_BITRATE,
+            Self::Mcs(_) => NL80211_RATE_INFO_MCS,
+            Self::MhzWidth(1) => NL80211_RATE_INFO_1_MHZ_WIDTH,
+            Self::MhzWidth(2) => NL80211_RATE_INFO_2_MHZ_WIDTH,
+            Self::MhzWidth(4) => NL80211_RATE_INFO_4_MHZ_WIDTH,
+            Self::MhzWidth(5) => NL80211_RATE_INFO_5_MHZ_WIDTH,
+            Self::MhzWidth(8) => NL80211_RATE_INFO_8_MHZ_WIDTH,
+            Self::MhzWidth(10) => NL80211_RATE_INFO_10_MHZ_WIDTH,
+            Self::MhzWidth(16) => NL80211_RATE_INFO_16_MHZ_WIDTH,
+            Self::MhzWidth(40) => NL80211_RATE_INFO_40_MHZ_WIDTH,
+            Self::MhzWidth(80) => NL80211_RATE_INFO_80_MHZ_WIDTH,
+            Self::MhzWidth(160) => NL80211_RATE_INFO_160_MHZ_WIDTH,
+            Self::MhzWidth(320) => NL80211_RATE_INFO_320_MHZ_WIDTH,
+            Self::MhzWidth(freq) => {
+                log::warn!("Invalid Nl80211RateInfo::MhzWidth {:?}", freq);
+                u16::MAX
+            }
+            Self::MhzWidth80Plus80 => NL80211_RATE_INFO_80P80_MHZ_WIDTH,
+            Self::ShortGi => NL80211_RATE_INFO_SHORT_GI,
+            Self::Bitrate32(_) => NL80211_RATE_INFO_BITRATE32,
+            Self::VhtMcs(_) => NL80211_RATE_INFO_VHT_MCS,
+            Self::VhtNss(_) => NL80211_RATE_INFO_VHT_NSS,
+            Self::HeMcs(_) => NL80211_RATE_INFO_HE_MCS,
+            Self::HeNss(_) => NL80211_RATE_INFO_HE_NSS,
+            Self::HeGi(_) => NL80211_RATE_INFO_HE_GI,
+            Self::HeDcm(_) => NL80211_RATE_INFO_HE_DCM,
+            Self::HeRuAlloc(_) => NL80211_RATE_INFO_HE_RU_ALLOC,
+            Self::S1gMcs(_) => NL80211_RATE_INFO_S1G_MCS,
+            Self::S1gNss(_) => NL80211_RATE_INFO_S1G_NSS,
+            Self::EhtMcs(_) => NL80211_RATE_INFO_EHT_MCS,
+            Self::EhtNss(_) => NL80211_RATE_INFO_EHT_NSS,
+            Self::EhtGi(_) => NL80211_RATE_INFO_EHT_GI,
+            Self::EhtRuAlloc(_) => NL80211_RATE_INFO_EHT_RU_ALLOC,
+            Self::Other(info) => info.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::Bitrate(bitrate) => NativeEndian::write_u16(buffer, *bitrate),
+            Self::Mcs(d)
+            | Self::VhtMcs(d)
+            | Self::VhtNss(d)
+            | Self::HeMcs(d)
+            | Self::HeNss(d)
+            | Self::HeDcm(d)
+            | Self::S1gMcs(d)
+            | Self::S1gNss(d)
+            | Self::EhtMcs(d)
+            | Self::EhtNss(d) => buffer[0] = *d,
+            Self::MhzWidth(_) | Self::ShortGi | Self::MhzWidth80Plus80 => (),
+            Self::Bitrate32(bitrate) => {
+                NativeEndian::write_u32(buffer, *bitrate)
+            }
+            Self::HeGi(d) => buffer[0] = (*d).into(),
+            Self::HeRuAlloc(d) => buffer[0] = (*d).into(),
+            Self::EhtGi(d) => buffer[0] = (*d).into(),
+            Self::EhtRuAlloc(d) => buffer[0] = (*d).into(),
+            Self::Other(ref nlas) => nlas.emit(buffer),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
+    for Nl80211RateInfo
+{
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            NL80211_RATE_INFO_BITRATE => {
+                let err_msg = format!(
+                    "Invalid NL80211_RATE_INFO_BITRATE value {:?}",
+                    payload
+                );
+                Self::Bitrate(parse_u16(payload).context(err_msg)?)
+            }
+            NL80211_RATE_INFO_MCS => {
+                let err_msg = format!(
+                    "Invalid NL80211_RATE_INFO_MCS value {:?}",
+                    payload
+                );
+                Self::Mcs(parse_u8(payload).context(err_msg)?)
+            }
+            NL80211_RATE_INFO_1_MHZ_WIDTH => Self::MhzWidth(1),
+            NL80211_RATE_INFO_2_MHZ_WIDTH => Self::MhzWidth(2),
+            NL80211_RATE_INFO_4_MHZ_WIDTH => Self::MhzWidth(4),
+            NL80211_RATE_INFO_5_MHZ_WIDTH => Self::MhzWidth(5),
+            NL80211_RATE_INFO_8_MHZ_WIDTH => Self::MhzWidth(8),
+            NL80211_RATE_INFO_10_MHZ_WIDTH => Self::MhzWidth(10),
+            NL80211_RATE_INFO_16_MHZ_WIDTH => Self::MhzWidth(16),
+            NL80211_RATE_INFO_40_MHZ_WIDTH => Self::MhzWidth(40),
+            NL80211_RATE_INFO_80_MHZ_WIDTH => Self::MhzWidth(80),
+            NL80211_RATE_INFO_160_MHZ_WIDTH => Self::MhzWidth(160),
+            NL80211_RATE_INFO_320_MHZ_WIDTH => Self::MhzWidth(320),
+            NL80211_RATE_INFO_80P80_MHZ_WIDTH => Self::MhzWidth80Plus80,
+            NL80211_RATE_INFO_SHORT_GI => Self::ShortGi,
+            NL80211_RATE_INFO_BITRATE32 => {
+                let err_msg = format!(
+                    "Invalid NL80211_RATE_INFO_BITRATE32 value {:?}",
+                    payload
+                );
+                Self::Bitrate32(parse_u32(payload).context(err_msg)?)
+            }
+            NL80211_RATE_INFO_VHT_MCS => {
+                let err_msg = format!(
+                    "Invalid NL80211_RATE_INFO_VHT_MCS value {:?}",
+                    payload
+                );
+                Self::VhtMcs(parse_u8(payload).context(err_msg)?)
+            }
+            NL80211_RATE_INFO_VHT_NSS => {
+                let err_msg = format!(
+                    "Invalid NL80211_RATE_INFO_VHT_NSS value {:?}",
+                    payload
+                );
+                Self::VhtNss(parse_u8(payload).context(err_msg)?)
+            }
+            NL80211_RATE_INFO_HE_MCS => {
+                let err_msg = format!(
+                    "Invalid NL80211_RATE_INFO_HE_MCS value {:?}",
+                    payload
+                );
+                Self::HeMcs(parse_u8(payload).context(err_msg)?)
+            }
+            NL80211_RATE_INFO_HE_NSS => {
+                let err_msg = format!(
+                    "Invalid NL80211_RATE_INFO_HE_NSS value {:?}",
+                    payload
+                );
+                Self::HeNss(parse_u8(payload).context(err_msg)?)
+            }
+            NL80211_RATE_INFO_HE_GI => {
+                //
+                let err_msg = format!(
+                    "Invalid NL80211_RATE_INFO_HE_GI value {:?}",
+                    payload
+                );
+                Self::HeGi(parse_u8(payload).context(err_msg)?.into())
+            }
+            NL80211_RATE_INFO_HE_DCM => {
+                let err_msg = format!(
+                    "Invalid NL80211_RATE_INFO_HE_DCM value {:?}",
+                    payload
+                );
+                Self::HeDcm(parse_u8(payload).context(err_msg)?)
+            }
+            NL80211_RATE_INFO_HE_RU_ALLOC => {
+                //
+                let err_msg = format!(
+                    "Invalid NL80211_RATE_INFO_HE_RU_ALLOC value {:?}",
+                    payload
+                );
+                Self::HeRuAlloc(parse_u8(payload).context(err_msg)?.into())
+            }
+            NL80211_RATE_INFO_S1G_MCS => {
+                let err_msg = format!(
+                    "Invalid NL80211_RATE_INFO_S1G_MCS value {:?}",
+                    payload
+                );
+                Self::S1gMcs(parse_u8(payload).context(err_msg)?)
+            }
+            NL80211_RATE_INFO_S1G_NSS => {
+                let err_msg = format!(
+                    "Invalid NL80211_RATE_INFO_S1G_NSS value {:?}",
+                    payload
+                );
+                Self::S1gNss(parse_u8(payload).context(err_msg)?)
+            }
+            NL80211_RATE_INFO_EHT_MCS => {
+                let err_msg = format!(
+                    "Invalid NL80211_RATE_INFO_EHT_MCS value {:?}",
+                    payload
+                );
+                Self::EhtMcs(parse_u8(payload).context(err_msg)?)
+            }
+            NL80211_RATE_INFO_EHT_NSS => {
+                let err_msg = format!(
+                    "Invalid NL80211_RATE_INFO_EHT_NSS value {:?}",
+                    payload
+                );
+                Self::EhtNss(parse_u8(payload).context(err_msg)?)
+            }
+            NL80211_RATE_INFO_EHT_GI => {
+                //
+                let err_msg = format!(
+                    "Invalid NL80211_RATE_INFO_EHT_GI value {:?}",
+                    payload
+                );
+                Self::EhtGi(parse_u8(payload).context(err_msg)?.into())
+            }
+            NL80211_RATE_INFO_EHT_RU_ALLOC => {
+                //
+                let err_msg = format!(
+                    "Invalid NL80211_RATE_INFO_EHT_RU_ALLOC value {:?}",
+                    payload
+                );
+                Self::EhtRuAlloc(parse_u8(payload).context(err_msg)?.into())
+            }
+            _ => Self::Other(
+                DefaultNla::parse(buf).context("invalid NLA (unknown kind)")?,
+            ),
+        })
+    }
+}
+
+const NL80211_RATE_INFO_HE_GI_0_8: u8 = 0;
+const NL80211_RATE_INFO_HE_GI_1_6: u8 = 1;
+const NL80211_RATE_INFO_HE_GI_3_2: u8 = 2;
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum Nl80211HeGi {
+    /// 0.8 usec
+    Usec0_8,
+    /// 1.6 usec
+    Usec1_6,
+    /// 3.2 usec
+    Usec3_2,
+
+    Other(u8),
+}
+
+impl From<u8> for Nl80211HeGi {
+    fn from(d: u8) -> Self {
+        match d {
+            NL80211_RATE_INFO_HE_GI_0_8 => Self::Usec0_8,
+            NL80211_RATE_INFO_HE_GI_1_6 => Self::Usec1_6,
+            NL80211_RATE_INFO_HE_GI_3_2 => Self::Usec3_2,
+            _ => Self::Other(d),
+        }
+    }
+}
+
+impl From<Nl80211HeGi> for u8 {
+    fn from(v: Nl80211HeGi) -> u8 {
+        match v {
+            Nl80211HeGi::Usec0_8 => NL80211_RATE_INFO_HE_GI_0_8,
+            Nl80211HeGi::Usec1_6 => NL80211_RATE_INFO_HE_GI_1_6,
+            Nl80211HeGi::Usec3_2 => NL80211_RATE_INFO_HE_GI_3_2,
+            Nl80211HeGi::Other(d) => d,
+        }
+    }
+}
+
+const NL80211_RATE_INFO_HE_RU_ALLOC_26: u8 = 0;
+const NL80211_RATE_INFO_HE_RU_ALLOC_52: u8 = 1;
+const NL80211_RATE_INFO_HE_RU_ALLOC_106: u8 = 2;
+const NL80211_RATE_INFO_HE_RU_ALLOC_242: u8 = 3;
+const NL80211_RATE_INFO_HE_RU_ALLOC_484: u8 = 4;
+const NL80211_RATE_INFO_HE_RU_ALLOC_996: u8 = 5;
+const NL80211_RATE_INFO_HE_RU_ALLOC_2X996: u8 = 6;
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum Nl80211HeRuAllocation {
+    Tone(u32),
+    Tone2x996,
+
+    Other(u8),
+}
+
+impl From<u8> for Nl80211HeRuAllocation {
+    fn from(d: u8) -> Self {
+        match d {
+            NL80211_RATE_INFO_HE_RU_ALLOC_26 => Self::Tone(26),
+            NL80211_RATE_INFO_HE_RU_ALLOC_52 => Self::Tone(52),
+            NL80211_RATE_INFO_HE_RU_ALLOC_106 => Self::Tone(106),
+            NL80211_RATE_INFO_HE_RU_ALLOC_242 => Self::Tone(242),
+            NL80211_RATE_INFO_HE_RU_ALLOC_484 => Self::Tone(484),
+            NL80211_RATE_INFO_HE_RU_ALLOC_996 => Self::Tone(996),
+            NL80211_RATE_INFO_HE_RU_ALLOC_2X996 => Self::Tone2x996,
+            _ => Self::Other(d),
+        }
+    }
+}
+
+impl From<Nl80211HeRuAllocation> for u8 {
+    fn from(v: Nl80211HeRuAllocation) -> u8 {
+        match v {
+            Nl80211HeRuAllocation::Tone(26) => NL80211_RATE_INFO_HE_RU_ALLOC_26,
+            Nl80211HeRuAllocation::Tone(52) => NL80211_RATE_INFO_HE_RU_ALLOC_52,
+            Nl80211HeRuAllocation::Tone(106) => {
+                NL80211_RATE_INFO_HE_RU_ALLOC_106
+            }
+            Nl80211HeRuAllocation::Tone(242) => {
+                NL80211_RATE_INFO_HE_RU_ALLOC_242
+            }
+            Nl80211HeRuAllocation::Tone(484) => {
+                NL80211_RATE_INFO_HE_RU_ALLOC_484
+            }
+            Nl80211HeRuAllocation::Tone(996) => {
+                NL80211_RATE_INFO_HE_RU_ALLOC_996
+            }
+            Nl80211HeRuAllocation::Tone(_) => {
+                log::warn!("Invalid Nl80211HeRuAllocation {:?}", v);
+                u8::MAX
+            }
+            Nl80211HeRuAllocation::Tone2x996 => {
+                NL80211_RATE_INFO_HE_RU_ALLOC_2X996
+            }
+            Nl80211HeRuAllocation::Other(d) => d,
+        }
+    }
+}
+
+const NL80211_RATE_INFO_EHT_GI_0_8: u8 = 0;
+const NL80211_RATE_INFO_EHT_GI_1_6: u8 = 1;
+const NL80211_RATE_INFO_EHT_GI_3_2: u8 = 2;
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum Nl80211EhtGi {
+    /// 0.8 usec
+    Usec0_8,
+    /// 1.6 usec
+    Usec1_6,
+    /// 3.2 usec
+    Usec3_2,
+
+    Other(u8),
+}
+
+impl From<u8> for Nl80211EhtGi {
+    fn from(d: u8) -> Self {
+        match d {
+            NL80211_RATE_INFO_EHT_GI_0_8 => Self::Usec0_8,
+            NL80211_RATE_INFO_EHT_GI_1_6 => Self::Usec1_6,
+            NL80211_RATE_INFO_EHT_GI_3_2 => Self::Usec3_2,
+            _ => Self::Other(d),
+        }
+    }
+}
+
+impl From<Nl80211EhtGi> for u8 {
+    fn from(v: Nl80211EhtGi) -> u8 {
+        match v {
+            Nl80211EhtGi::Usec0_8 => NL80211_RATE_INFO_EHT_GI_0_8,
+            Nl80211EhtGi::Usec1_6 => NL80211_RATE_INFO_EHT_GI_1_6,
+            Nl80211EhtGi::Usec3_2 => NL80211_RATE_INFO_EHT_GI_3_2,
+            Nl80211EhtGi::Other(d) => d,
+        }
+    }
+}
+
+const NL80211_RATE_INFO_EHT_RU_ALLOC_26: u8 = 0;
+const NL80211_RATE_INFO_EHT_RU_ALLOC_52: u8 = 1;
+const NL80211_RATE_INFO_EHT_RU_ALLOC_52P26: u8 = 2;
+const NL80211_RATE_INFO_EHT_RU_ALLOC_106: u8 = 3;
+const NL80211_RATE_INFO_EHT_RU_ALLOC_106P26: u8 = 4;
+const NL80211_RATE_INFO_EHT_RU_ALLOC_242: u8 = 5;
+const NL80211_RATE_INFO_EHT_RU_ALLOC_484: u8 = 6;
+const NL80211_RATE_INFO_EHT_RU_ALLOC_484P242: u8 = 7;
+const NL80211_RATE_INFO_EHT_RU_ALLOC_996: u8 = 8;
+const NL80211_RATE_INFO_EHT_RU_ALLOC_996P484: u8 = 9;
+const NL80211_RATE_INFO_EHT_RU_ALLOC_996P484P242: u8 = 10;
+const NL80211_RATE_INFO_EHT_RU_ALLOC_2X996: u8 = 11;
+const NL80211_RATE_INFO_EHT_RU_ALLOC_2X996P484: u8 = 12;
+const NL80211_RATE_INFO_EHT_RU_ALLOC_3X996: u8 = 13;
+const NL80211_RATE_INFO_EHT_RU_ALLOC_3X996P484: u8 = 14;
+const NL80211_RATE_INFO_EHT_RU_ALLOC_4X996: u8 = 15;
+
+/// EHT RU allocation values
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum Nl80211EhtRuAllocation {
+    Tone(u32),
+    Tone52Plus26,
+    Tone106Plus26,
+    Tone484Plus242,
+    Tone996Plus484,
+    Tone996Plus484Plus242,
+    Tone2x996,
+    Tone2x996Plus484,
+    Tone3x996,
+    Tone3x996Plus484,
+    Tone4x996,
+
+    Other(u8),
+}
+
+impl From<u8> for Nl80211EhtRuAllocation {
+    fn from(d: u8) -> Self {
+        match d {
+            NL80211_RATE_INFO_EHT_RU_ALLOC_26 => Self::Tone(26),
+            NL80211_RATE_INFO_EHT_RU_ALLOC_52 => Self::Tone(52),
+            NL80211_RATE_INFO_EHT_RU_ALLOC_52P26 => Self::Tone52Plus26,
+            NL80211_RATE_INFO_EHT_RU_ALLOC_106 => Self::Tone(106),
+            NL80211_RATE_INFO_EHT_RU_ALLOC_106P26 => Self::Tone106Plus26,
+            NL80211_RATE_INFO_EHT_RU_ALLOC_242 => Self::Tone(242),
+            NL80211_RATE_INFO_EHT_RU_ALLOC_484 => Self::Tone(484),
+            NL80211_RATE_INFO_EHT_RU_ALLOC_484P242 => Self::Tone484Plus242,
+            NL80211_RATE_INFO_EHT_RU_ALLOC_996 => Self::Tone(996),
+            NL80211_RATE_INFO_EHT_RU_ALLOC_996P484 => Self::Tone996Plus484,
+            NL80211_RATE_INFO_EHT_RU_ALLOC_996P484P242 => {
+                Self::Tone996Plus484Plus242
+            }
+            NL80211_RATE_INFO_EHT_RU_ALLOC_2X996 => Self::Tone2x996,
+            NL80211_RATE_INFO_EHT_RU_ALLOC_2X996P484 => Self::Tone2x996Plus484,
+            NL80211_RATE_INFO_EHT_RU_ALLOC_3X996 => Self::Tone3x996,
+            NL80211_RATE_INFO_EHT_RU_ALLOC_3X996P484 => Self::Tone3x996Plus484,
+            NL80211_RATE_INFO_EHT_RU_ALLOC_4X996 => Self::Tone4x996,
+            _ => Self::Other(d),
+        }
+    }
+}
+
+impl From<Nl80211EhtRuAllocation> for u8 {
+    fn from(v: Nl80211EhtRuAllocation) -> u8 {
+        match v {
+            Nl80211EhtRuAllocation::Tone(26) => {
+                NL80211_RATE_INFO_EHT_RU_ALLOC_26
+            }
+            Nl80211EhtRuAllocation::Tone(52) => {
+                NL80211_RATE_INFO_EHT_RU_ALLOC_52
+            }
+            Nl80211EhtRuAllocation::Tone(106) => {
+                NL80211_RATE_INFO_EHT_RU_ALLOC_106
+            }
+            Nl80211EhtRuAllocation::Tone(242) => {
+                NL80211_RATE_INFO_EHT_RU_ALLOC_242
+            }
+            Nl80211EhtRuAllocation::Tone(484) => {
+                NL80211_RATE_INFO_EHT_RU_ALLOC_484
+            }
+            Nl80211EhtRuAllocation::Tone(996) => {
+                NL80211_RATE_INFO_EHT_RU_ALLOC_996
+            }
+            Nl80211EhtRuAllocation::Tone(_) => {
+                log::warn!("Invalid Nl80211EhtRuAllocation {:?}", v);
+                u8::MAX
+            }
+            Nl80211EhtRuAllocation::Tone52Plus26 => {
+                NL80211_RATE_INFO_EHT_RU_ALLOC_52P26
+            }
+            Nl80211EhtRuAllocation::Tone106Plus26 => {
+                NL80211_RATE_INFO_EHT_RU_ALLOC_106P26
+            }
+            Nl80211EhtRuAllocation::Tone484Plus242 => {
+                NL80211_RATE_INFO_EHT_RU_ALLOC_484P242
+            }
+            Nl80211EhtRuAllocation::Tone996Plus484 => {
+                NL80211_RATE_INFO_EHT_RU_ALLOC_996P484
+            }
+            Nl80211EhtRuAllocation::Tone996Plus484Plus242 => {
+                NL80211_RATE_INFO_EHT_RU_ALLOC_996P484P242
+            }
+            Nl80211EhtRuAllocation::Tone2x996 => {
+                NL80211_RATE_INFO_EHT_RU_ALLOC_2X996
+            }
+            Nl80211EhtRuAllocation::Tone2x996Plus484 => {
+                NL80211_RATE_INFO_EHT_RU_ALLOC_2X996P484
+            }
+            Nl80211EhtRuAllocation::Tone3x996 => {
+                NL80211_RATE_INFO_EHT_RU_ALLOC_3X996
+            }
+            Nl80211EhtRuAllocation::Tone3x996Plus484 => {
+                NL80211_RATE_INFO_EHT_RU_ALLOC_3X996P484
+            }
+            Nl80211EhtRuAllocation::Tone4x996 => {
+                NL80211_RATE_INFO_EHT_RU_ALLOC_4X996
+            }
+            Nl80211EhtRuAllocation::Other(d) => d,
+        }
+    }
+}

--- a/src/station/station_info.rs
+++ b/src/station/station_info.rs
@@ -1,0 +1,1034 @@
+// SPDX-License-Identifier: MIT
+
+use std::convert::TryInto;
+
+use anyhow::Context;
+use byteorder::{ByteOrder, NativeEndian};
+use netlink_packet_utils::{
+    nla::{DefaultNla, Nla, NlaBuffer, NlasIterator},
+    parsers::{parse_u16, parse_u32, parse_u64, parse_u8},
+    Emitable, Parseable,
+};
+
+use std::fmt::Debug;
+
+use crate::NestedNl80211TidStats;
+
+use super::Nl80211RateInfo;
+
+const NL80211_STA_INFO_INACTIVE_TIME: u16 = 1;
+const NL80211_STA_INFO_RX_BYTES: u16 = 2;
+const NL80211_STA_INFO_TX_BYTES: u16 = 3;
+const NL80211_STA_INFO_LLID: u16 = 4;
+const NL80211_STA_INFO_PLID: u16 = 5;
+const NL80211_STA_INFO_PLINK_STATE: u16 = 6;
+const NL80211_STA_INFO_SIGNAL: u16 = 7;
+const NL80211_STA_INFO_TX_BITRATE: u16 = 8;
+const NL80211_STA_INFO_RX_PACKETS: u16 = 9;
+const NL80211_STA_INFO_TX_PACKETS: u16 = 10;
+const NL80211_STA_INFO_TX_RETRIES: u16 = 11;
+const NL80211_STA_INFO_TX_FAILED: u16 = 12;
+const NL80211_STA_INFO_SIGNAL_AVG: u16 = 13;
+const NL80211_STA_INFO_RX_BITRATE: u16 = 14;
+const NL80211_STA_INFO_BSS_PARAM: u16 = 15;
+const NL80211_STA_INFO_CONNECTED_TIME: u16 = 16;
+const NL80211_STA_INFO_STA_FLAGS: u16 = 17;
+const NL80211_STA_INFO_BEACON_LOSS: u16 = 18;
+const NL80211_STA_INFO_T_OFFSET: u16 = 19;
+const NL80211_STA_INFO_LOCAL_PM: u16 = 20;
+const NL80211_STA_INFO_PEER_PM: u16 = 21;
+const NL80211_STA_INFO_NONPEER_PM: u16 = 22;
+const NL80211_STA_INFO_RX_BYTES64: u16 = 23;
+const NL80211_STA_INFO_TX_BYTES64: u16 = 24;
+const NL80211_STA_INFO_CHAIN_SIGNAL: u16 = 25;
+const NL80211_STA_INFO_CHAIN_SIGNAL_AVG: u16 = 26;
+const NL80211_STA_INFO_EXPECTED_THROUGHPUT: u16 = 27;
+const NL80211_STA_INFO_RX_DROP_MISC: u16 = 28;
+const NL80211_STA_INFO_BEACON_RX: u16 = 29;
+const NL80211_STA_INFO_BEACON_SIGNAL_AVG: u16 = 30;
+const NL80211_STA_INFO_TID_STATS: u16 = 31;
+const NL80211_STA_INFO_RX_DURATION: u16 = 32;
+const NL80211_STA_INFO_ACK_SIGNAL: u16 = 34;
+const NL80211_STA_INFO_ACK_SIGNAL_AVG: u16 = 35;
+const NL80211_STA_INFO_RX_MPDUS: u16 = 36;
+const NL80211_STA_INFO_FCS_ERROR_COUNT: u16 = 37;
+const NL80211_STA_INFO_CONNECTED_TO_GATE: u16 = 38;
+const NL80211_STA_INFO_TX_DURATION: u16 = 39;
+const NL80211_STA_INFO_AIRTIME_WEIGHT: u16 = 40;
+const NL80211_STA_INFO_AIRTIME_LINK_METRIC: u16 = 41;
+const NL80211_STA_INFO_ASSOC_AT_BOOTTIME: u16 = 42;
+const NL80211_STA_INFO_CONNECTED_TO_AS: u16 = 43;
+
+/// Station information
+///
+/// These attribute types are used with [`Nl80211Attr::Nl80211StationInfo`]
+/// when getting information about a station.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum Nl80211StationInfo {
+    /// Time since last activity (msecs)
+    InactiveTime(u32),
+    /// Total transmitted bytes (MPDU length)
+    TxBytes(u32),
+    /// Total received bytes (MPDU length)
+    RxBytes(u32),
+    /// Total transmitted bytes (MPDU length)
+    TxBytes64(u64),
+    /// Total received bytes (MPDU length)
+    RxBytes64(u64),
+    /// Signal strength of last received PPDU (dBm)
+    Signal(u8),
+    /// Signal strength average (u8, dBm)
+    SignalAvg(u8),
+    /// Current unicast transmission rate, nested attribute containing info as
+    /// possible, see [`Nl80211RateInfo`]
+    TxBitrate(Vec<Nl80211RateInfo>),
+    ///  Last unicast data frame receive rate, nested attribute, like
+    /// [`NL80211_STA_INFO_TX_BITRATE`].
+    RxBitrate(Vec<Nl80211RateInfo>),
+    /// Total transmitted packets (MSDUs and MMPDUs)
+    TxPackets(u32),
+    /// Total received packets (MSDUs and MMPDUs)
+    RxPackets(u32),
+    /// Total number of received packets (MPDUs)
+    RxMpdus(u32),
+    /// Total retries (MPDUs)
+    TxRetries(u32),
+    /// Total failed packets (MPDUs) (u32, to this station)
+    TxFailed(u32),
+    /// Transmitted packets dropped for unspecified reasons
+    RxDropMisc(u64),
+    /// Total number of packets (MPDUs) received with an FCS error . This count
+    /// may not include some packets with an FCS error due to TA corruption.
+    /// Hence this counter might not be fully accurate.
+    FcsErrorCount(u32),
+    /// The station's mesh LLID
+    Llid(u16),
+    /// The station's mesh PLID
+    Plid(u16),
+    /// Peer link state for the station (see [`Nl80211PeerLinkState`])
+    PeerLinkState(Nl80211PeerLinkState),
+    /// Current station's view of BSS, nested attribute containing info as
+    /// possible, see [`Nl80211StationBssParam`]
+    BssParam(Vec<Nl80211StationBssParam>),
+    /// Time since the station is last connected
+    ConnectedTime(u32),
+    /// Contains a [Nl80211StationFlagUpdate]
+    StationFlags(Nl80211StationFlagUpdate),
+    /// Timing offset with respect to this station
+    TimingOffset(i64),
+    /// Local mesh staion link-specific power mode
+    LocalPowerMode(Nl80211MeshPowerMode),
+    /// Peer mesh staion link-specific power mode
+    PeerPowerMode(Nl80211MeshPowerMode),
+    /// Neighbor mesh station power save mode towards non-peer station
+    NonPeerPowerMode(Nl80211MeshPowerMode),
+    /// Per-chain signal strength of last PPDU. Contains a nested array of
+    /// signal strength attributes (dBm)
+    ChainSignal(Vec<u8>),
+    /// Per-chain signal strength average. Same format as
+    /// [`Nl80211StationInfo::ChainSignal`]
+    ChainSignalAvg(Vec<u8>),
+    /// Expected throughput considering also the 802.11 header (kbps)
+    ExpectedThroughput(u32),
+    /// Number of beacons received from this peer
+    BeaconRx(u64),
+    /// Signal strength average for beacons only (dBm)
+    BeaconSignalAvg(u8),
+    /// Count of times beacon loss was detected
+    BeaconLoss(u32),
+    /// This is a nested attribute where each the inner attribute number is the
+    /// TID+1 and the special TID 16 (i.e. value 17) is used for non-QoS
+    /// frames; each one of those is again nested with &enum nl80211_tid_stats
+    /// attributes carrying the actual values.
+    TidStats(Vec<NestedNl80211TidStats>),
+    /// Aggregate PPDU duration for all frames sent to the station (usec)
+    TxDuration(u64),
+    /// Aggregate PPDU duration for all frames received from the station (usec)
+    RxDuration(u64),
+    /// Signal strength of the last ACK frame (dBm)
+    AckSignal(u8),
+    /// Average signal strength of ACK frames (dBm)
+    AckSignalAvg(i8),
+    /// Set to true if the station has a path to a mesh gate
+    ConnectedToGate(bool),
+    /// Current airtime weight for station
+    AirtimeWeight(u16),
+    /// Airtime link metric for mesh station
+    AirtimeLinkMetric(u16),
+    /// Timestamp (nanoseconds) of station's association
+    AssociationAtBoottime(u64),
+    /// Set to true if the station has a path to an authentication server
+    ConnectedToAuthServer(bool),
+
+    Other(DefaultNla),
+}
+
+impl Nla for Nl80211StationInfo {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::Signal(_)
+            | Self::SignalAvg(_)
+            | Self::PeerLinkState(_)
+            | Self::AckSignal(_)
+            | Self::AckSignalAvg(_)
+            | Self::BeaconSignalAvg(_)
+            | Self::ConnectedToGate(_)
+            | Self::ConnectedToAuthServer(_) => 1,
+            Self::Llid(_)
+            | Self::Plid(_)
+            | Self::AirtimeWeight(_)
+            | Self::AirtimeLinkMetric(_) => 2,
+            Self::InactiveTime(_)
+            | Self::TxBytes(_)
+            | Self::RxBytes(_)
+            | Self::TxPackets(_)
+            | Self::RxPackets(_)
+            | Self::RxMpdus(_)
+            | Self::TxRetries(_)
+            | Self::TxFailed(_)
+            | Self::FcsErrorCount(_)
+            | Self::ConnectedTime(_)
+            | Self::LocalPowerMode(_)
+            | Self::PeerPowerMode(_)
+            | Self::NonPeerPowerMode(_)
+            | Self::ExpectedThroughput(_)
+            | Self::BeaconLoss(_) => 4,
+            Self::TxBytes64(_)
+            | Self::RxBytes64(_)
+            | Self::RxDropMisc(_)
+            | Self::StationFlags(_)
+            | Self::TimingOffset(_)
+            | Self::BeaconRx(_)
+            | Self::TxDuration(_)
+            | Self::RxDuration(_)
+            | Self::AssociationAtBoottime(_) => 8,
+            Self::TxBitrate(ref nlas) | Self::RxBitrate(ref nlas) => {
+                nlas.as_slice().buffer_len()
+            }
+            Self::BssParam(ref nlas) => nlas.as_slice().buffer_len(),
+            Self::ChainSignal(d) | Self::ChainSignalAvg(d) => d.len(),
+            Self::TidStats(ref nlas) => nlas.as_slice().buffer_len(),
+            Self::Other(attr) => attr.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Nl80211StationInfo::InactiveTime(_) => {
+                NL80211_STA_INFO_INACTIVE_TIME
+            }
+            Nl80211StationInfo::TxBytes(_) => NL80211_STA_INFO_TX_BYTES,
+            Nl80211StationInfo::RxBytes(_) => NL80211_STA_INFO_RX_BYTES,
+            Nl80211StationInfo::TxBytes64(_) => NL80211_STA_INFO_TX_BYTES64,
+            Nl80211StationInfo::RxBytes64(_) => NL80211_STA_INFO_RX_BYTES64,
+            Nl80211StationInfo::Signal(_) => NL80211_STA_INFO_SIGNAL,
+            Nl80211StationInfo::SignalAvg(_) => NL80211_STA_INFO_SIGNAL_AVG,
+            Nl80211StationInfo::TxBitrate(_) => NL80211_STA_INFO_TX_BITRATE,
+            Nl80211StationInfo::RxBitrate(_) => NL80211_STA_INFO_RX_BITRATE,
+            Nl80211StationInfo::TxPackets(_) => NL80211_STA_INFO_TX_PACKETS,
+            Nl80211StationInfo::RxPackets(_) => NL80211_STA_INFO_RX_PACKETS,
+            Nl80211StationInfo::RxMpdus(_) => NL80211_STA_INFO_RX_MPDUS,
+            Nl80211StationInfo::TxRetries(_) => NL80211_STA_INFO_TX_RETRIES,
+            Nl80211StationInfo::TxFailed(_) => NL80211_STA_INFO_TX_FAILED,
+            Nl80211StationInfo::RxDropMisc(_) => NL80211_STA_INFO_RX_DROP_MISC,
+            Nl80211StationInfo::FcsErrorCount(_) => {
+                NL80211_STA_INFO_FCS_ERROR_COUNT
+            }
+            Nl80211StationInfo::Llid(_) => NL80211_STA_INFO_LLID,
+            Nl80211StationInfo::Plid(_) => NL80211_STA_INFO_PLID,
+            Nl80211StationInfo::PeerLinkState(_) => {
+                NL80211_STA_INFO_PLINK_STATE
+            }
+            Nl80211StationInfo::BssParam(_) => NL80211_STA_INFO_BSS_PARAM,
+            Nl80211StationInfo::ConnectedTime(_) => {
+                NL80211_STA_INFO_CONNECTED_TIME
+            }
+            Nl80211StationInfo::StationFlags(_) => NL80211_STA_INFO_STA_FLAGS,
+            Nl80211StationInfo::TimingOffset(_) => NL80211_STA_INFO_T_OFFSET,
+            Nl80211StationInfo::LocalPowerMode(_) => NL80211_STA_INFO_LOCAL_PM,
+            Nl80211StationInfo::PeerPowerMode(_) => NL80211_STA_INFO_PEER_PM,
+            Nl80211StationInfo::NonPeerPowerMode(_) => {
+                NL80211_STA_INFO_NONPEER_PM
+            }
+            Nl80211StationInfo::ChainSignal(_) => NL80211_STA_INFO_CHAIN_SIGNAL,
+            Nl80211StationInfo::ChainSignalAvg(_) => {
+                NL80211_STA_INFO_CHAIN_SIGNAL_AVG
+            }
+            Nl80211StationInfo::ExpectedThroughput(_) => {
+                NL80211_STA_INFO_EXPECTED_THROUGHPUT
+            }
+            Nl80211StationInfo::BeaconRx(_) => NL80211_STA_INFO_BEACON_RX,
+            Nl80211StationInfo::BeaconSignalAvg(_) => {
+                NL80211_STA_INFO_BEACON_SIGNAL_AVG
+            }
+            Nl80211StationInfo::BeaconLoss(_) => NL80211_STA_INFO_BEACON_LOSS,
+            Nl80211StationInfo::TidStats(_) => NL80211_STA_INFO_TID_STATS,
+            Nl80211StationInfo::TxDuration(_) => NL80211_STA_INFO_TX_DURATION,
+            Nl80211StationInfo::RxDuration(_) => NL80211_STA_INFO_RX_DURATION,
+            Nl80211StationInfo::AckSignal(_) => NL80211_STA_INFO_ACK_SIGNAL,
+            Nl80211StationInfo::AckSignalAvg(_) => {
+                NL80211_STA_INFO_ACK_SIGNAL_AVG
+            }
+            Nl80211StationInfo::ConnectedToGate(_) => {
+                NL80211_STA_INFO_CONNECTED_TO_GATE
+            }
+            Nl80211StationInfo::AirtimeWeight(_) => {
+                NL80211_STA_INFO_AIRTIME_WEIGHT
+            }
+            Nl80211StationInfo::AirtimeLinkMetric(_) => {
+                NL80211_STA_INFO_AIRTIME_LINK_METRIC
+            }
+            Nl80211StationInfo::AssociationAtBoottime(_) => {
+                NL80211_STA_INFO_ASSOC_AT_BOOTTIME
+            }
+            Nl80211StationInfo::ConnectedToAuthServer(_) => {
+                NL80211_STA_INFO_CONNECTED_TO_AS
+            }
+            Self::Other(attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Nl80211StationInfo::Signal(d)
+            | Nl80211StationInfo::SignalAvg(d)
+            | Nl80211StationInfo::BeaconSignalAvg(d)
+            | Nl80211StationInfo::AckSignal(d) => buffer[0] = *d,
+            Nl80211StationInfo::AckSignalAvg(d) => buffer[0] = *d as u8,
+            Nl80211StationInfo::Llid(d)
+            | Nl80211StationInfo::Plid(d)
+            | Nl80211StationInfo::AirtimeWeight(d)
+            | Nl80211StationInfo::AirtimeLinkMetric(d) => {
+                NativeEndian::write_u16(buffer, *d)
+            }
+            Nl80211StationInfo::InactiveTime(d)
+            | Nl80211StationInfo::TxBytes(d)
+            | Nl80211StationInfo::RxBytes(d)
+            | Nl80211StationInfo::TxPackets(d)
+            | Nl80211StationInfo::RxPackets(d)
+            | Nl80211StationInfo::RxMpdus(d)
+            | Nl80211StationInfo::TxRetries(d)
+            | Nl80211StationInfo::TxFailed(d)
+            | Nl80211StationInfo::FcsErrorCount(d)
+            | Nl80211StationInfo::ConnectedTime(d)
+            | Nl80211StationInfo::ExpectedThroughput(d)
+            | Nl80211StationInfo::BeaconLoss(d) => {
+                NativeEndian::write_u32(buffer, *d)
+            }
+            Nl80211StationInfo::TxBytes64(d)
+            | Nl80211StationInfo::RxBytes64(d)
+            | Nl80211StationInfo::RxDropMisc(d)
+            | Nl80211StationInfo::BeaconRx(d)
+            | Nl80211StationInfo::TxDuration(d)
+            | Nl80211StationInfo::RxDuration(d)
+            | Nl80211StationInfo::AssociationAtBoottime(d) => {
+                NativeEndian::write_u64(buffer, *d)
+            }
+            Nl80211StationInfo::TimingOffset(d) => {
+                NativeEndian::write_i64(buffer, *d)
+            }
+            Nl80211StationInfo::TxBitrate(nlas)
+            | Nl80211StationInfo::RxBitrate(nlas) => {
+                nlas.as_slice().emit(buffer)
+            }
+            Nl80211StationInfo::PeerLinkState(d) => buffer[0] = (*d).into(),
+            Nl80211StationInfo::BssParam(nlas) => nlas.as_slice().emit(buffer),
+            Nl80211StationInfo::StationFlags(d) => {
+                NativeEndian::write_u32(&mut buffer[0..4], (&d.mask).into());
+                NativeEndian::write_u32(&mut buffer[4..8], (&d.set).into());
+            }
+            Nl80211StationInfo::LocalPowerMode(d)
+            | Nl80211StationInfo::PeerPowerMode(d)
+            | Nl80211StationInfo::NonPeerPowerMode(d) => {
+                NativeEndian::write_u32(buffer, (*d).into())
+            }
+            Nl80211StationInfo::ChainSignal(d)
+            | Nl80211StationInfo::ChainSignalAvg(d) => {
+                buffer.copy_from_slice((*d).as_slice())
+            }
+            Nl80211StationInfo::TidStats(nlas) => nlas.as_slice().emit(buffer),
+            Nl80211StationInfo::ConnectedToGate(d)
+            | Nl80211StationInfo::ConnectedToAuthServer(d) => {
+                buffer[0] = (*d).into()
+            }
+            Self::Other(ref attr) => attr.emit(buffer),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
+    for Nl80211StationInfo
+{
+    fn parse(
+        buf: &NlaBuffer<&'a T>,
+    ) -> Result<Self, netlink_packet_utils::DecodeError> {
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            NL80211_STA_INFO_INACTIVE_TIME => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_INACTIVE_TIME value {:?}",
+                    payload
+                );
+                Self::InactiveTime(parse_u32(payload).context(err_msg)?)
+            }
+            NL80211_STA_INFO_RX_BYTES => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_RX_BYTES value {:?}",
+                    payload
+                );
+                Self::RxBytes(parse_u32(payload).context(err_msg)?)
+            }
+            NL80211_STA_INFO_TX_BYTES => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_TX_BYTES value {:?}",
+                    payload
+                );
+                Self::TxBytes(parse_u32(payload).context(err_msg)?)
+            }
+            NL80211_STA_INFO_LLID => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_LLID value {:?}",
+                    payload
+                );
+                Self::Llid(parse_u16(payload).context(err_msg)?)
+            }
+            NL80211_STA_INFO_PLID => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_PLID value {:?}",
+                    payload
+                );
+                Self::Plid(parse_u16(payload).context(err_msg)?)
+            }
+            NL80211_STA_INFO_PLINK_STATE => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_PLINK_STATE value {:?}",
+                    payload
+                );
+                Self::PeerLinkState(parse_u8(payload).context(err_msg)?.into())
+            }
+            NL80211_STA_INFO_SIGNAL => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_SIGNAL value {:?}",
+                    payload
+                );
+                Self::Signal(parse_u8(payload).context(err_msg)?)
+            }
+            NL80211_STA_INFO_TX_BITRATE => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_TX_BITRATE value {:?}",
+                    payload
+                );
+                let mut nlas = Vec::new();
+                for nla in NlasIterator::new(payload) {
+                    let nla = &nla.context(err_msg.clone())?;
+                    nlas.push(
+                        Nl80211RateInfo::parse(nla).context(err_msg.clone())?,
+                    );
+                }
+                Self::TxBitrate(nlas)
+            }
+            NL80211_STA_INFO_RX_PACKETS => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_RX_PACKETS value {:?}",
+                    payload
+                );
+                Self::RxPackets(parse_u32(payload).context(err_msg)?)
+            }
+            NL80211_STA_INFO_TX_PACKETS => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_TX_PACKETS value {:?}",
+                    payload
+                );
+                Self::TxPackets(parse_u32(payload).context(err_msg)?)
+            }
+            NL80211_STA_INFO_TX_RETRIES => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_TX_RETRIES value {:?}",
+                    payload
+                );
+                Self::TxRetries(parse_u32(payload).context(err_msg)?)
+            }
+            NL80211_STA_INFO_TX_FAILED => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_TX_FAILED value {:?}",
+                    payload
+                );
+                Self::TxFailed(parse_u32(payload).context(err_msg)?)
+            }
+            NL80211_STA_INFO_SIGNAL_AVG => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_SIGNAL_AVG value {:?}",
+                    payload
+                );
+                Self::SignalAvg(parse_u8(payload).context(err_msg)?)
+            }
+            NL80211_STA_INFO_RX_BITRATE => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_RX_BITRATE value {:?}",
+                    payload
+                );
+                let mut nlas = Vec::new();
+                for nla in NlasIterator::new(payload) {
+                    let nla = &nla.context(err_msg.clone())?;
+                    nlas.push(
+                        Nl80211RateInfo::parse(nla).context(err_msg.clone())?,
+                    );
+                }
+                Self::RxBitrate(nlas)
+            }
+            NL80211_STA_INFO_BSS_PARAM => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_BSS_PARAM value {:?}",
+                    payload
+                );
+                let mut nlas = Vec::new();
+                for nla in NlasIterator::new(payload) {
+                    let nla = &nla.context(err_msg.clone())?;
+                    nlas.push(
+                        Nl80211StationBssParam::parse(nla)
+                            .context(err_msg.clone())?,
+                    );
+                }
+                Self::BssParam(nlas)
+            }
+            NL80211_STA_INFO_CONNECTED_TIME => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_CONNECTED_TIME value {:?}",
+                    payload
+                );
+                Self::ConnectedTime(parse_u32(payload).context(err_msg)?)
+            }
+            NL80211_STA_INFO_STA_FLAGS => {
+                Self::StationFlags(if payload.len() == 8 {
+                    let err_msg = format!(
+                        "Invalid NL80211_STA_INFO_STA_FLAGS value {:?}",
+                        payload
+                    );
+                    let mask =
+                        parse_u32(&payload[0..4]).context(err_msg.clone())?;
+                    let set = parse_u32(&payload[4..8]).context(err_msg)?;
+                    Nl80211StationFlagUpdate {
+                        mask: mask.into(),
+                        set: set.into(),
+                    }
+                } else {
+                    return Err(format!(
+                    "Invalid length of NL80211_STA_INFO_STA_FLAGS, expected length {} got {:?}",
+                    8, payload
+                )
+                .into());
+                })
+            }
+            NL80211_STA_INFO_BEACON_LOSS => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_BEACON_LOSS value {:?}",
+                    payload
+                );
+                Self::BeaconLoss(parse_u32(payload).context(err_msg)?)
+            }
+            NL80211_STA_INFO_T_OFFSET => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_T_OFFSET value {:?}",
+                    payload
+                );
+                Self::TimingOffset(i64::from_ne_bytes(
+                    payload.try_into().context(err_msg)?,
+                ))
+            }
+            NL80211_STA_INFO_LOCAL_PM => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_LOCAL_PM value {:?}",
+                    payload
+                );
+                Self::LocalPowerMode(
+                    parse_u32(payload).context(err_msg)?.into(),
+                )
+            }
+            NL80211_STA_INFO_PEER_PM => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_PEER_PM value {:?}",
+                    payload
+                );
+                Self::PeerPowerMode(parse_u32(payload).context(err_msg)?.into())
+            }
+            NL80211_STA_INFO_NONPEER_PM => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_NONPEER_PM value {:?}",
+                    payload
+                );
+                Self::NonPeerPowerMode(
+                    parse_u32(payload).context(err_msg)?.into(),
+                )
+            }
+            NL80211_STA_INFO_RX_BYTES64 => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_RX_BYTES64 value {:?}",
+                    payload
+                );
+                Self::RxBytes64(parse_u64(payload).context(err_msg)?)
+            }
+            NL80211_STA_INFO_TX_BYTES64 => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_TX_BYTES64 value {:?}",
+                    payload
+                );
+                Self::TxBytes64(parse_u64(payload).context(err_msg)?)
+            }
+            NL80211_STA_INFO_CHAIN_SIGNAL => {
+                Self::ChainSignal(Vec::from(payload))
+            }
+            NL80211_STA_INFO_CHAIN_SIGNAL_AVG => {
+                Self::ChainSignalAvg(Vec::from(payload))
+            }
+            NL80211_STA_INFO_EXPECTED_THROUGHPUT => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_EXPECTED_THROUGHPUT value {:?}",
+                    payload
+                );
+                Self::ExpectedThroughput(parse_u32(payload).context(err_msg)?)
+            }
+            NL80211_STA_INFO_RX_DROP_MISC => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_RX_DROP_MISC value {:?}",
+                    payload
+                );
+                Self::RxDropMisc(parse_u64(payload).context(err_msg)?)
+            }
+            NL80211_STA_INFO_BEACON_RX => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_BEACON_RX value {:?}",
+                    payload
+                );
+                Self::BeaconRx(parse_u64(payload).context(err_msg)?)
+            }
+            NL80211_STA_INFO_BEACON_SIGNAL_AVG => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_BEACON_SIGNAL_AVG value {:?}",
+                    payload
+                );
+                Self::BeaconSignalAvg(parse_u8(payload).context(err_msg)?)
+            }
+            NL80211_STA_INFO_TID_STATS => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_TID_STATS value {:?}",
+                    payload
+                );
+                let mut nlas = Vec::new();
+                let _t = NlasIterator::new(payload);
+                for nla in NlasIterator::new(payload) {
+                    let nla = &nla.context(err_msg.clone())?;
+                    nlas.push(
+                        NestedNl80211TidStats::parse(nla)
+                            .context(err_msg.clone())?,
+                    );
+                }
+                Self::TidStats(nlas)
+            }
+            NL80211_STA_INFO_RX_DURATION => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_RX_DURATION value {:?}",
+                    payload
+                );
+                Self::RxDuration(parse_u64(payload).context(err_msg)?)
+            }
+            NL80211_STA_INFO_ACK_SIGNAL => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_ACK_SIGNAL value {:?}",
+                    payload
+                );
+                Self::AckSignal(parse_u8(payload).context(err_msg)?)
+            }
+            NL80211_STA_INFO_ACK_SIGNAL_AVG => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_ACK_SIGNAL_AVG value {:?}",
+                    payload
+                );
+                Self::AckSignalAvg(*payload.first().context(err_msg)? as i8)
+            }
+            NL80211_STA_INFO_RX_MPDUS => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_RX_MPDUS value {:?}",
+                    payload
+                );
+                Self::RxMpdus(parse_u32(payload).context(err_msg)?)
+            }
+            NL80211_STA_INFO_FCS_ERROR_COUNT => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_FCS_ERROR_COUNT value {:?}",
+                    payload
+                );
+                Self::FcsErrorCount(parse_u32(payload).context(err_msg)?)
+            }
+            NL80211_STA_INFO_CONNECTED_TO_GATE => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_CONNECTED_TO_GATE value {:?}",
+                    payload
+                );
+                Self::ConnectedToGate(parse_u8(payload).context(err_msg)? == 1)
+            }
+            NL80211_STA_INFO_TX_DURATION => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_TX_DURATION value {:?}",
+                    payload
+                );
+                Self::TxDuration(parse_u64(payload).context(err_msg)?)
+            }
+            NL80211_STA_INFO_AIRTIME_WEIGHT => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_AIRTIME_WEIGHT value {:?}",
+                    payload
+                );
+                Self::AirtimeWeight(parse_u16(payload).context(err_msg)?)
+            }
+            NL80211_STA_INFO_AIRTIME_LINK_METRIC => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_AIRTIME_LINK_METRIC value {:?}",
+                    payload
+                );
+                Self::AirtimeLinkMetric(parse_u16(payload).context(err_msg)?)
+            }
+            NL80211_STA_INFO_ASSOC_AT_BOOTTIME => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_ASSOC_AT_BOOTTIME value {:?}",
+                    payload
+                );
+                Self::AssociationAtBoottime(
+                    parse_u64(payload).context(err_msg)?,
+                )
+            }
+            NL80211_STA_INFO_CONNECTED_TO_AS => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_INFO_CONNECTED_TO_AS value {:?}",
+                    payload
+                );
+                Self::ConnectedToAuthServer(
+                    parse_u8(payload).context(err_msg)? == 1,
+                )
+            }
+            _ => Self::Other(
+                DefaultNla::parse(buf).context("invalid NLA (unknown kind)")?,
+            ),
+        })
+    }
+}
+
+pub const NL80211_PLINK_LISTEN: u8 = 0;
+pub const NL80211_PLINK_OPN_SNT: u8 = 1;
+pub const NL80211_PLINK_OPN_RCVD: u8 = 2;
+pub const NL80211_PLINK_CNF_RCVD: u8 = 3;
+pub const NL80211_PLINK_ESTAB: u8 = 4;
+pub const NL80211_PLINK_HOLDING: u8 = 5;
+pub const NL80211_PLINK_BLOCKED: u8 = 6;
+
+/// State of a mesh peer link finite state machine
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum Nl80211PeerLinkState {
+    /// Initial state, considered the implicit state of non existent mesh peer
+    /// links
+    Listen,
+    /// Mesh peer link open frame has been sent to this mesh peer
+    OpenSent,
+    /// Mesh plink open frame has been received from this mesh peer
+    OpenReceived,
+    /// Mesh plink confirm frame has been received from this mesh peer
+    ConfirmReceived,
+    /// Mesh peer link is established
+    Established,
+    /// Mesh peer link is being closed or cancelled
+    Holding,
+    /// All frames transmitted from this mesh plink are discarded, except for
+    /// authentication frames
+    Blocked,
+    Other(u8),
+}
+
+impl From<u8> for Nl80211PeerLinkState {
+    fn from(d: u8) -> Self {
+        match d {
+            NL80211_PLINK_LISTEN => Self::Listen,
+            NL80211_PLINK_OPN_SNT => Self::OpenSent,
+            NL80211_PLINK_OPN_RCVD => Self::OpenReceived,
+            NL80211_PLINK_CNF_RCVD => Self::ConfirmReceived,
+            NL80211_PLINK_ESTAB => Self::Established,
+            NL80211_PLINK_HOLDING => Self::Holding,
+            NL80211_PLINK_BLOCKED => Self::Blocked,
+            _ => Self::Other(d),
+        }
+    }
+}
+
+impl From<Nl80211PeerLinkState> for u8 {
+    fn from(v: Nl80211PeerLinkState) -> u8 {
+        match v {
+            Nl80211PeerLinkState::Listen => NL80211_PLINK_LISTEN,
+            Nl80211PeerLinkState::OpenSent => NL80211_PLINK_OPN_SNT,
+            Nl80211PeerLinkState::OpenReceived => NL80211_PLINK_OPN_RCVD,
+            Nl80211PeerLinkState::ConfirmReceived => NL80211_PLINK_CNF_RCVD,
+            Nl80211PeerLinkState::Established => NL80211_PLINK_ESTAB,
+            Nl80211PeerLinkState::Holding => NL80211_PLINK_HOLDING,
+            Nl80211PeerLinkState::Blocked => NL80211_PLINK_BLOCKED,
+            Nl80211PeerLinkState::Other(d) => d,
+        }
+    }
+}
+
+const NL80211_STA_BSS_PARAM_CTS_PROT: u16 = 1;
+const NL80211_STA_BSS_PARAM_SHORT_PREAMBLE: u16 = 2;
+const NL80211_STA_BSS_PARAM_SHORT_SLOT_TIME: u16 = 3;
+const NL80211_STA_BSS_PARAM_DTIM_PERIOD: u16 = 4;
+const NL80211_STA_BSS_PARAM_BEACON_INTERVAL: u16 = 5;
+
+/// BSS information collected by station
+///
+/// These attribute types are used with [`Nl80211StationInfo::BssParam`]
+/// when getting information about the bitrate of a station.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum Nl80211StationBssParam {
+    CtsProtection,
+    ShortPreamble,
+    ShortSlotTime,
+    /// DTIM period for beaconing
+    DtimPeriod(u8),
+    BeaconInterval(u16),
+
+    Other(DefaultNla),
+}
+
+impl Nla for Nl80211StationBssParam {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::CtsProtection | Self::ShortPreamble | Self::ShortSlotTime => {
+                0
+            }
+            Self::DtimPeriod(_) => 1,
+            Self::BeaconInterval(_) | Self::Other(_) => 2,
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::CtsProtection => NL80211_STA_BSS_PARAM_CTS_PROT,
+            Self::ShortPreamble => NL80211_STA_BSS_PARAM_SHORT_PREAMBLE,
+            Self::ShortSlotTime => NL80211_STA_BSS_PARAM_SHORT_SLOT_TIME,
+            Self::DtimPeriod(_) => NL80211_STA_BSS_PARAM_DTIM_PERIOD,
+            Self::BeaconInterval(_) => NL80211_STA_BSS_PARAM_BEACON_INTERVAL,
+            Self::Other(d) => d.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::CtsProtection | Self::ShortPreamble | Self::ShortSlotTime => {
+            }
+            Self::DtimPeriod(d) => buffer[0] = *d,
+            Self::BeaconInterval(d) => NativeEndian::write_u16(buffer, *d),
+            Self::Other(d) => (*d).emit(buffer),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
+    for Nl80211StationBssParam
+{
+    fn parse(
+        buf: &NlaBuffer<&'a T>,
+    ) -> Result<Self, netlink_packet_utils::DecodeError> {
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            NL80211_STA_BSS_PARAM_CTS_PROT => Self::CtsProtection,
+            NL80211_STA_BSS_PARAM_SHORT_PREAMBLE => Self::ShortPreamble,
+            NL80211_STA_BSS_PARAM_SHORT_SLOT_TIME => Self::ShortSlotTime,
+            NL80211_STA_BSS_PARAM_DTIM_PERIOD => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_BSS_PARAM_DTIM_PERIOD value {:?}",
+                    payload
+                );
+                Self::DtimPeriod(parse_u8(payload).context(err_msg)?)
+            }
+            NL80211_STA_BSS_PARAM_BEACON_INTERVAL => {
+                let err_msg = format!(
+                    "Invalid NL80211_STA_BSS_PARAM_BEACON_INTERVAL value {:?}",
+                    payload
+                );
+                Self::BeaconInterval(parse_u16(payload).context(err_msg)?)
+            }
+            _ => Self::Other(
+                DefaultNla::parse(buf).context("invalid NLA (unknown kind)")?,
+            ),
+        })
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Nl80211StationFlagUpdate {
+    /// Mask of station flags to set
+    mask: VecNl80211StationFlag,
+    /// Which values to set them to
+    set: VecNl80211StationFlag,
+}
+
+pub const NL80211_STA_FLAG_AUTHORIZED: u32 = 1;
+pub const NL80211_STA_FLAG_SHORT_PREAMBLE: u32 = 2;
+pub const NL80211_STA_FLAG_WME: u32 = 3;
+pub const NL80211_STA_FLAG_MFP: u32 = 4;
+pub const NL80211_STA_FLAG_AUTHENTICATED: u32 = 5;
+pub const NL80211_STA_FLAG_TDLS_PEER: u32 = 6;
+pub const NL80211_STA_FLAG_ASSOCIATED: u32 = 7;
+
+/// Station flags
+///
+/// When a station is added to an AP interface, it is assumed to
+/// be already associated (and hence authenticated.)
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
+pub(crate) struct VecNl80211StationFlag(pub Vec<Nl80211StationFlag>);
+
+#[non_exhaustive]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum Nl80211StationFlag {
+    /// Station is authorized (802.1X)
+    Authorized,
+    /// Station is capable of receiving frames with short barker preamble
+    ShortPreamble,
+    /// Station is WME/QoS capable
+    Wme,
+    /// Station uses management frame protection
+    Mfp,
+    /// Station is authenticated
+    Authenticated,
+    /// Station is a TDLS peer. This flag should only be used in managed mode
+    /// (even in the flags mask). Note that the flag can't be changed, it is
+    /// only valid while adding a station, and attempts to change it will
+    /// silently be ignored (rather than rejected as errors.)
+    TdlsPeer,
+    /// station is associated; used with drivers that support
+    /// [`NL80211_FEATURE_FULL_AP_CLIENT_STATE`] to transition a previously
+    /// added station into associated state
+    Associated,
+    // Reserved: 25 bits,
+    Other(u32),
+}
+
+impl From<u32> for Nl80211StationFlag {
+    fn from(d: u32) -> Self {
+        match d {
+            NL80211_STA_FLAG_AUTHORIZED => Self::Authorized,
+            NL80211_STA_FLAG_SHORT_PREAMBLE => Self::ShortPreamble,
+            NL80211_STA_FLAG_WME => Self::Wme,
+            NL80211_STA_FLAG_MFP => Self::Mfp,
+            NL80211_STA_FLAG_AUTHENTICATED => Self::Authenticated,
+            NL80211_STA_FLAG_TDLS_PEER => Self::TdlsPeer,
+            NL80211_STA_FLAG_ASSOCIATED => Self::Associated,
+            _ => Self::Other(d),
+        }
+    }
+}
+
+impl From<Nl80211StationFlag> for u32 {
+    fn from(v: Nl80211StationFlag) -> Self {
+        match v {
+            Nl80211StationFlag::Authorized => NL80211_STA_FLAG_AUTHORIZED,
+            Nl80211StationFlag::ShortPreamble => {
+                NL80211_STA_FLAG_SHORT_PREAMBLE
+            }
+            Nl80211StationFlag::Wme => NL80211_STA_FLAG_WME,
+            Nl80211StationFlag::Mfp => NL80211_STA_FLAG_MFP,
+            Nl80211StationFlag::Authenticated => NL80211_STA_FLAG_AUTHENTICATED,
+            Nl80211StationFlag::TdlsPeer => NL80211_STA_FLAG_TDLS_PEER,
+            Nl80211StationFlag::Associated => NL80211_STA_FLAG_ASSOCIATED,
+            Nl80211StationFlag::Other(d) => d,
+        }
+    }
+}
+
+impl std::fmt::Display for Nl80211StationFlag {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Nl80211StationFlag::Authorized => write!(f, "AUTHORIZED"),
+            Nl80211StationFlag::ShortPreamble => write!(f, "SHORT_PREAMBLE"),
+            Nl80211StationFlag::Wme => write!(f, "WME"),
+            Nl80211StationFlag::Mfp => write!(f, "MFP"),
+            Nl80211StationFlag::Authenticated => write!(f, "AUTHENTICATED"),
+            Nl80211StationFlag::TdlsPeer => write!(f, "TDLS_PEER"),
+            Nl80211StationFlag::Associated => write!(f, "ASSOCIATED"),
+            Nl80211StationFlag::Other(d) => write!(f, "Other({d})"),
+        }
+    }
+}
+
+const ALL_STATION_FLAGS: [Nl80211StationFlag; 7] = [
+    Nl80211StationFlag::Associated,
+    Nl80211StationFlag::Authenticated,
+    Nl80211StationFlag::Authorized,
+    Nl80211StationFlag::Mfp,
+    Nl80211StationFlag::ShortPreamble,
+    Nl80211StationFlag::TdlsPeer,
+    Nl80211StationFlag::Wme,
+];
+
+impl From<u32> for VecNl80211StationFlag {
+    fn from(d: u32) -> Self {
+        let mut got: u32 = 0;
+        let mut ret = Vec::new();
+
+        for flag in ALL_STATION_FLAGS {
+            if (d & u32::from(flag)) > 0 {
+                ret.push(flag);
+                got += u32::from(flag);
+            }
+        }
+        if got != d {
+            ret.push(Nl80211StationFlag::Other(d - got));
+        }
+
+        Self(ret)
+    }
+}
+
+impl From<&VecNl80211StationFlag> for u32 {
+    fn from(v: &VecNl80211StationFlag) -> u32 {
+        let mut d: u32 = 0;
+        for flag in &v.0 {
+            d += u32::from(*flag);
+        }
+        d
+    }
+}
+
+pub const NL80211_MESH_POWER_UNKNOWN: u32 = 0;
+pub const NL80211_MESH_POWER_ACTIVE: u32 = 1;
+pub const NL80211_MESH_POWER_LIGHT_SLEEP: u32 = 2;
+pub const NL80211_MESH_POWER_DEEP_SLEEP: u32 = 3;
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum Nl80211MeshPowerMode {
+    Unknown,
+    Active,
+    LightSleep,
+    DeepSleep,
+
+    Other(u32),
+}
+
+impl From<u32> for Nl80211MeshPowerMode {
+    fn from(d: u32) -> Self {
+        match d {
+            NL80211_MESH_POWER_UNKNOWN => Self::Unknown,
+            NL80211_MESH_POWER_ACTIVE => Self::Active,
+            NL80211_MESH_POWER_LIGHT_SLEEP => Self::LightSleep,
+            NL80211_MESH_POWER_DEEP_SLEEP => Self::DeepSleep,
+            _ => Self::Other(d),
+        }
+    }
+}
+
+impl From<Nl80211MeshPowerMode> for u32 {
+    fn from(v: Nl80211MeshPowerMode) -> u32 {
+        match v {
+            Nl80211MeshPowerMode::Unknown => NL80211_MESH_POWER_UNKNOWN,
+            Nl80211MeshPowerMode::Active => NL80211_MESH_POWER_ACTIVE,
+            Nl80211MeshPowerMode::LightSleep => NL80211_MESH_POWER_LIGHT_SLEEP,
+            Nl80211MeshPowerMode::DeepSleep => NL80211_MESH_POWER_DEEP_SLEEP,
+            Nl80211MeshPowerMode::Other(d) => d,
+        }
+    }
+}


### PR DESCRIPTION
Add station get command and all prequesite enums, along with
a station dump example.

Also adds bitflags dependency to ease handling of flags.