### PR TITLE
New release 0.2.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,17 @@
 # Changelog
+## [0.2.0] - 2024-09-21
+### Breaking changes
+ - Changed `Nl80211Attr::WiPhyFreq` to `Nl80211Attr::WiphyFreq`. (2a4dbe1)
+ - Changed `Nl80211StationInfo::Signal` from u8 to i8. (79e4010)
+ - Changed Nl80211Message.nlas to Nl80211Message.attributes. (1b6679d)
+
+### New features
+ - Add support of parsing netlink message reply of `iw phy`. (2a4dbe1)
+ - Add support of station. (19d03a5)
+
+### Bug fixes
+ - N/A
+
 ## [0.1.2] - 2023-07-10
 ### Breaking changes
  - N/A

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # The crate name `nl80211` is occupied
 name = "wl-nl80211"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "MIT"
 edition = "2021"


### PR DESCRIPTION
=== Breaking changes
 - Changed `Nl80211Attr::WiPhyFreq` to `Nl80211Attr::WiphyFreq`. (2a4dbe1)
 - Changed `Nl80211StationInfo::Signal` from u8 to i8. (79e4010)
 - Changed Nl80211Message.nlas to Nl80211Message.attributes. (1b6679d)

=== New features
 - Add support of parsing netlink message reply of `iw phy`. (2a4dbe1)
 - Add support of station. (19d03a5)

=== Bug fixes
 - N/A