### PR TITLE
Nl80211Element: Fix length check to allow zero-length ssid

### DIFF
--- a/src/element.rs
+++ b/src/element.rs
@@ -117,7 +117,7 @@ impl Nl80211Element {
 impl<T: AsRef<[u8]> + ?Sized> Parseable<T> for Nl80211Element {
     fn parse(buf: &T) -> Result<Self, DecodeError> {
         let buf = buf.as_ref();
-        if buf.len() <= 2 {
+        if buf.len() < 2 {
             return Err(
                 format!("Invalid length of Nl80211Element {buf:?}").into()
             );


### PR DESCRIPTION
This commit modifies the length check in `Nl80211Element::parse` from `if buf.len() <= 2` to `if buf.len() < 2`. 

The original condition caused errors when parsing elements with a length of 0, such as an SSID element with zero length (e.g., [0, 0] for a hidden SSID). 

Allowing `buf.len() == 2` ensures valid parsing of zero-length elements without causing out-of-bounds errors.

#22 