### PR TITLE
Add method to change interface type

### DIFF
--- a/.github/workflows/clippy-rustfmt.yml
+++ b/.github/workflows/clippy-rustfmt.yml
@@ -28,7 +28,9 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: clippy-tokio-socket
-        run: cargo clippy
+        run: cargo clippy -- -D warnings
 
       - name: clippy-smol-socket
-        run: cargo clippy --no-default-features --features smol_socket
+        run: |
+            cargo clippy \
+              --no-default-features --features smol_socket -- -D warnings

--- a/examples/dump_nl80211_iface.rs
+++ b/examples/dump_nl80211_iface.rs
@@ -22,6 +22,6 @@ async fn get_interfaces() {
     }
     assert!(!msgs.is_empty());
     for msg in msgs {
-        println!("{:?}", msg);
+        println!("{msg:?}");
     }
 }

--- a/examples/dump_nl80211_scan.rs
+++ b/examples/dump_nl80211_scan.rs
@@ -37,6 +37,6 @@ async fn dump_scan(if_index: u32) {
     }
     assert!(!msgs.is_empty());
     for msg in msgs {
-        println!("{:?}", msg);
+        println!("{msg:?}");
     }
 }

--- a/examples/dump_nl80211_station.rs
+++ b/examples/dump_nl80211_station.rs
@@ -37,6 +37,6 @@ async fn dump_station(if_index: u32) {
     }
     assert!(!msgs.is_empty());
     for msg in msgs {
-        println!("{:?}", msg);
+        println!("{msg:?}");
     }
 }

--- a/examples/dump_nl80211_wiphy.rs
+++ b/examples/dump_nl80211_wiphy.rs
@@ -22,6 +22,6 @@ async fn get_wireless_physics() {
     }
     assert!(!msgs.is_empty());
     for msg in msgs {
-        println!("{:?}", msg);
+        println!("{msg:?}");
     }
 }

--- a/examples/nl80211_trigger_scan.rs
+++ b/examples/nl80211_trigger_scan.rs
@@ -50,6 +50,6 @@ async fn dump_scan(if_index: u32) {
     }
     assert!(!msgs.is_empty());
     for msg in msgs {
-        println!("{:?}", msg);
+        println!("{msg:?}");
     }
 }

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -911,24 +911,23 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nl80211Attr {
         Ok(match buf.kind() {
             NL80211_ATTR_IFINDEX => {
                 let err_msg =
-                    format!("Invalid NL80211_ATTR_IFINDEX value {:?}", payload);
+                    format!("Invalid NL80211_ATTR_IFINDEX value {payload:?}");
                 Self::IfIndex(parse_u32(payload).context(err_msg)?)
             }
             NL80211_ATTR_WIPHY => {
                 let err_msg =
-                    format!("Invalid NL80211_ATTR_WIPHY value {:?}", payload);
+                    format!("Invalid NL80211_ATTR_WIPHY value {payload:?}");
                 Self::Wiphy(parse_u32(payload).context(err_msg)?)
             }
             NL80211_ATTR_WIPHY_NAME => {
                 let err_msg = format!(
-                    "Invalid NL80211_ATTR_WIPHY_NAME value {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_WIPHY_NAME value {payload:?}"
                 );
                 Self::WiphyName(parse_string(payload).context(err_msg)?)
             }
             NL80211_ATTR_IFNAME => {
                 let err_msg =
-                    format!("Invalid NL80211_ATTR_IFNAME value {:?}", payload);
+                    format!("Invalid NL80211_ATTR_IFNAME value {payload:?}");
                 Self::IfName(parse_string(payload).context(err_msg)?)
             }
             NL80211_ATTR_IFTYPE => {
@@ -936,7 +935,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nl80211Attr {
             }
             NL80211_ATTR_WDEV => {
                 let err_msg =
-                    format!("Invalid NL80211_ATTR_WDEV value {:?}", payload);
+                    format!("Invalid NL80211_ATTR_WDEV value {payload:?}");
                 Self::Wdev(parse_u64(payload).context(err_msg)?)
             }
             NL80211_ATTR_MAC => Self::Mac(if payload.len() == ETH_ALEN {
@@ -946,8 +945,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nl80211Attr {
             } else {
                 return Err(format!(
                     "Invalid length of NL80211_ATTR_MAC, \
-                    expected length {} got {:?}",
-                    ETH_ALEN, payload
+                    expected length {ETH_ALEN} got {payload:?}"
                 )
                 .into());
             }),
@@ -959,8 +957,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nl80211Attr {
                 } else {
                     return Err(format!(
                         "Invalid length of NL80211_ATTR_MAC_MASK, \
-                        expected length {} got {:?}",
-                        ETH_ALEN, payload
+                        expected length {ETH_ALEN} got {payload:?}"
                     )
                     .into());
                 })
@@ -970,14 +967,13 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nl80211Attr {
             }
             NL80211_ATTR_GENERATION => {
                 let err_msg = format!(
-                    "Invalid NL80211_ATTR_GENERATION value {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_GENERATION value {payload:?}"
                 );
                 Self::Generation(parse_u32(payload).context(err_msg)?)
             }
             NL80211_ATTR_BSS => {
                 let err_msg =
-                    format!("Invalid NL80211_ATTR_BSS value {:?}", payload);
+                    format!("Invalid NL80211_ATTR_BSS value {payload:?}");
                 let mut nlas = Vec::new();
                 for nla in NlasIterator::new(payload) {
                     let nla = &nla.context(err_msg.clone())?;
@@ -987,27 +983,24 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nl80211Attr {
             }
             NL80211_ATTR_4ADDR => {
                 let err_msg =
-                    format!("Invalid NL80211_ATTR_4ADDR value {:?}", payload);
+                    format!("Invalid NL80211_ATTR_4ADDR value {payload:?}");
                 Self::Use4Addr(parse_u8(payload).context(err_msg)? > 0)
             }
             NL80211_ATTR_WIPHY_FREQ => {
                 let err_msg = format!(
-                    "Invalid NL80211_ATTR_WIPHY_FREQ value {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_WIPHY_FREQ value {payload:?}"
                 );
                 Self::WiphyFreq(parse_u32(payload).context(err_msg)?)
             }
             NL80211_ATTR_WIPHY_FREQ_OFFSET => {
                 let err_msg = format!(
-                    "Invalid NL80211_ATTR_WIPHY_FREQ_OFFSET value {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_WIPHY_FREQ_OFFSET value {payload:?}"
                 );
                 Self::WiphyFreqOffset(parse_u32(payload).context(err_msg)?)
             }
             NL80211_ATTR_WIPHY_CHANNEL_TYPE => {
                 let err_msg = format!(
-                    "Invalid NL80211_ATTR_WIPHY_CHANNEL_TYPE value {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_WIPHY_CHANNEL_TYPE value {payload:?}"
                 );
                 Self::WiphyChannelType(
                     parse_u32(payload).context(err_msg)?.into(),
@@ -1015,42 +1008,36 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nl80211Attr {
             }
             NL80211_ATTR_CHANNEL_WIDTH => {
                 let err_msg = format!(
-                    "Invalid NL80211_ATTR_CHANNEL_WIDTH value {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_CHANNEL_WIDTH value {payload:?}"
                 );
                 Self::ChannelWidth(parse_u32(payload).context(err_msg)?.into())
             }
             NL80211_ATTR_CENTER_FREQ1 => {
                 let err_msg = format!(
-                    "Invalid NL80211_ATTR_CENTER_FREQ1 value {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_CENTER_FREQ1 value {payload:?}"
                 );
                 Self::CenterFreq1(parse_u32(payload).context(err_msg)?)
             }
             NL80211_ATTR_CENTER_FREQ2 => {
                 let err_msg = format!(
-                    "Invalid NL80211_ATTR_CENTER_FREQ2 value {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_CENTER_FREQ2 value {payload:?}"
                 );
                 Self::CenterFreq2(parse_u32(payload).context(err_msg)?)
             }
             NL80211_ATTR_WIPHY_TX_POWER_LEVEL => {
                 let err_msg = format!(
-                    "Invalid NL80211_ATTR_WIPHY_TX_POWER_LEVEL value {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_WIPHY_TX_POWER_LEVEL value {payload:?}"
                 );
                 Self::WiphyTxPowerLevel(parse_u32(payload).context(err_msg)?)
             }
             NL80211_ATTR_SSID => {
                 let err_msg =
-                    format!("Invalid NL80211_ATTR_SSID value {:?}", payload);
+                    format!("Invalid NL80211_ATTR_SSID value {payload:?}");
                 Self::Ssid(parse_string(payload).context(err_msg)?)
             }
             NL80211_ATTR_STA_INFO => {
-                let err_msg = format!(
-                    "Invalid NL80211_ATTR_STA_INFO value {:?}",
-                    payload
-                );
+                let err_msg =
+                    format!("Invalid NL80211_ATTR_STA_INFO value {payload:?}");
                 let mut nlas = Vec::new();
                 for nla in NlasIterator::new(payload) {
                     let nla = &nla.context(err_msg.clone())?;
@@ -1062,10 +1049,8 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nl80211Attr {
                 Self::StationInfo(nlas)
             }
             NL80211_ATTR_TXQ_STATS => {
-                let err_msg = format!(
-                    "Invalid NL80211_ATTR_TXQ_STATS value {:?}",
-                    payload
-                );
+                let err_msg =
+                    format!("Invalid NL80211_ATTR_TXQ_STATS value {payload:?}");
                 let mut nlas = Vec::new();
                 for nla in NlasIterator::new(payload) {
                     let nla = &nla.context(err_msg.clone())?;
@@ -1092,10 +1077,8 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nl80211Attr {
                 )?)
             }
             NL80211_ATTR_MLO_LINKS => {
-                let err_msg = format!(
-                    "Invalid NL80211_ATTR_MLO_LINKS value {:?}",
-                    payload
-                );
+                let err_msg =
+                    format!("Invalid NL80211_ATTR_MLO_LINKS value {payload:?}");
                 let mut links = Vec::new();
                 for nla in NlasIterator::new(payload) {
                     let nla = &nla.context(err_msg.clone())?;
@@ -1107,71 +1090,61 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nl80211Attr {
             }
             NL80211_ATTR_WIPHY_RETRY_SHORT => {
                 let err_msg = format!(
-                    "Invalid NL80211_ATTR_WIPHY_RETRY_SHORT value {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_WIPHY_RETRY_SHORT value {payload:?}"
                 );
                 Self::WiphyRetryShort(parse_u8(payload).context(err_msg)?)
             }
             NL80211_ATTR_WIPHY_RETRY_LONG => {
                 let err_msg = format!(
-                    "Invalid NL80211_ATTR_WIPHY_RETRY_LONG value {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_WIPHY_RETRY_LONG value {payload:?}"
                 );
                 Self::WiphyRetryLong(parse_u8(payload).context(err_msg)?)
             }
             NL80211_ATTR_WIPHY_FRAG_THRESHOLD => {
                 let err_msg = format!(
-                    "Invalid NL80211_ATTR_WIPHY_FRAG_THRESHOLD value {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_WIPHY_FRAG_THRESHOLD value {payload:?}"
                 );
                 Self::WiphyFragThreshold(parse_u32(payload).context(err_msg)?)
             }
             NL80211_ATTR_WIPHY_RTS_THRESHOLD => {
                 let err_msg = format!(
-                    "Invalid NL80211_ATTR_WIPHY_RTS_THRESHOLD value {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_WIPHY_RTS_THRESHOLD value {payload:?}"
                 );
                 Self::WiphyRtsThreshold(parse_u32(payload).context(err_msg)?)
             }
             NL80211_ATTR_WIPHY_COVERAGE_CLASS => {
                 let err_msg = format!(
-                    "Invalid NL80211_ATTR_WIPHY_COVERAGE_CLASS value {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_WIPHY_COVERAGE_CLASS value {payload:?}"
                 );
                 Self::WiphyCoverageClass(parse_u8(payload).context(err_msg)?)
             }
             NL80211_ATTR_MAX_NUM_SCAN_SSIDS => {
                 let err_msg = format!(
-                    "Invalid NL80211_ATTR_MAX_NUM_SCAN_SSIDS value {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_MAX_NUM_SCAN_SSIDS value {payload:?}"
                 );
                 Self::MaxNumScanSsids(parse_u8(payload).context(err_msg)?)
             }
             NL80211_ATTR_MAX_NUM_SCHED_SCAN_SSIDS => {
                 let err_msg = format!(
-                    "Invalid NL80211_ATTR_MAX_NUM_SCHED_SCAN_SSIDS value {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_MAX_NUM_SCHED_SCAN_SSIDS value {payload:?}"
                 );
                 Self::MaxNumSchedScanSsids(parse_u8(payload).context(err_msg)?)
             }
             NL80211_ATTR_MAX_SCAN_IE_LEN => {
                 let err_msg = format!(
-                    "Invalid NL80211_ATTR_MAX_SCAN_IE_LEN value {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_MAX_SCAN_IE_LEN value {payload:?}"
                 );
                 Self::MaxScanIeLen(parse_u16(payload).context(err_msg)?)
             }
             NL80211_ATTR_MAX_SCHED_SCAN_IE_LEN => {
                 let err_msg = format!(
-                    "Invalid NL80211_ATTR_MAX_SCHED_SCAN_IE_LEN value {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_MAX_SCHED_SCAN_IE_LEN value {payload:?}"
                 );
                 Self::MaxSchedScanIeLen(parse_u16(payload).context(err_msg)?)
             }
             NL80211_ATTR_MAX_MATCH_SETS => {
                 let err_msg = format!(
-                    "Invalid NL80211_ATTR_MAX_MATCH_SETS value {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_MAX_MATCH_SETS value {payload:?}"
                 );
                 Self::MaxMatchSets(parse_u8(payload).context(err_msg)?)
             }
@@ -1183,8 +1156,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nl80211Attr {
             NL80211_ATTR_TDLS_EXTERNAL_SETUP => Self::TdlsExternalSetup,
             NL80211_ATTR_CIPHER_SUITES => {
                 let err_msg = format!(
-                    "Invalid NL80211_ATTR_CIPHER_SUITES value {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_CIPHER_SUITES value {payload:?}"
                 );
                 let mut suits = Vec::new();
                 for i in 0..(payload.len() / 4) {
@@ -1198,51 +1170,44 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nl80211Attr {
             }
             NL80211_ATTR_MAX_NUM_PMKIDS => {
                 let err_msg = format!(
-                    "Invalid NL80211_ATTR_MAX_NUM_PMKIDS value {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_MAX_NUM_PMKIDS value {payload:?}"
                 );
                 Self::MaxNumPmkids(parse_u8(payload).context(err_msg)?)
             }
             NL80211_ATTR_CONTROL_PORT_ETHERTYPE => Self::ControlPortEthertype,
             NL80211_ATTR_WIPHY_ANTENNA_AVAIL_TX => {
                 let err_msg = format!(
-                    "Invalid NL80211_ATTR_WIPHY_ANTENNA_AVAIL_TX value {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_WIPHY_ANTENNA_AVAIL_TX value {payload:?}"
                 );
                 Self::WiphyAntennaAvailTx(parse_u32(payload).context(err_msg)?)
             }
             NL80211_ATTR_WIPHY_ANTENNA_AVAIL_RX => {
                 let err_msg = format!(
-                    "Invalid NL80211_ATTR_WIPHY_ANTENNA_AVAIL_RX value {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_WIPHY_ANTENNA_AVAIL_RX value {payload:?}"
                 );
                 Self::WiphyAntennaAvailRx(parse_u32(payload).context(err_msg)?)
             }
             NL80211_ATTR_PROBE_RESP_OFFLOAD => {
                 let err_msg = format!(
-                    "Invalid NL80211_ATTR_PROBE_RESP_OFFLOAD value {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_PROBE_RESP_OFFLOAD value {payload:?}"
                 );
                 Self::ApProbeRespOffload(parse_u32(payload).context(err_msg)?)
             }
             NL80211_ATTR_WIPHY_ANTENNA_TX => {
                 let err_msg = format!(
-                    "Invalid NL80211_ATTR_WIPHY_ANTENNA_TX value {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_WIPHY_ANTENNA_TX value {payload:?}"
                 );
                 Self::WiphyAntennaTx(parse_u32(payload).context(err_msg)?)
             }
             NL80211_ATTR_WIPHY_ANTENNA_RX => {
                 let err_msg = format!(
-                    "Invalid NL80211_ATTR_WIPHY_ANTENNA_RX value {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_WIPHY_ANTENNA_RX value {payload:?}"
                 );
                 Self::WiphyAntennaRx(parse_u32(payload).context(err_msg)?)
             }
             NL80211_ATTR_SUPPORTED_IFTYPES => {
                 let err_msg = format!(
-                    "Invalid NL80211_ATTR_SUPPORTED_IFTYPES value {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_SUPPORTED_IFTYPES value {payload:?}"
                 );
                 let mut nlas = Vec::new();
                 for nla in NlasIterator::new(payload) {
@@ -1257,8 +1222,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nl80211Attr {
                 let mut nlas = Vec::new();
                 for nla in NlasIterator::new(payload) {
                     let err_msg = format!(
-                        "Invalid NL80211_ATTR_WIPHY_BANDS value {:?}",
-                        nla
+                        "Invalid NL80211_ATTR_WIPHY_BANDS value {nla:?}"
                     );
                     let nla = &nla.context(err_msg.clone())?;
                     nlas.push(Nl80211Band::parse(nla)?);
@@ -1283,8 +1247,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nl80211Attr {
                 for nla in NlasIterator::new(payload) {
                     let err_msg = format!(
                         "Invalid NL80211_ATTR_WOWLAN_TRIGGERS_SUPPORTED \
-                        value {:?}",
-                        nla
+                        value {nla:?}"
                     );
                     let nla = &nla.context(err_msg.clone())?;
                     nlas.push(Nl80211WowlanTrigersSupport::parse(nla)?);
@@ -1312,8 +1275,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nl80211Attr {
                 for (index, nla) in NlasIterator::new(payload).enumerate() {
                     let err_msg = format!(
                         "Invalid NL80211_ATTR_INTERFACE_COMBINATIONS \
-                        value {:?}",
-                        nla
+                        value {nla:?}"
                     );
                     let nla = &nla.context(err_msg.clone())?;
                     nlas.push(Nl80211IfaceComb::parse_with_param(
@@ -1330,8 +1292,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nl80211Attr {
                 let mut nlas = Vec::new();
                 for nla in NlasIterator::new(payload) {
                     let err_msg = format!(
-                        "Invalid NL80211_ATTR_RX_FRAME_TYPES value {:?}",
-                        nla
+                        "Invalid NL80211_ATTR_RX_FRAME_TYPES value {nla:?}"
                     );
                     let nla = &nla.context(err_msg.clone())?;
                     nlas.push(Nl80211IfaceFrameType::parse(nla)?);
@@ -1342,8 +1303,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nl80211Attr {
                 let mut nlas = Vec::new();
                 for nla in NlasIterator::new(payload) {
                     let err_msg = format!(
-                        "Invalid NL80211_ATTR_RX_FRAME_TYPES value {:?}",
-                        nla
+                        "Invalid NL80211_ATTR_RX_FRAME_TYPES value {nla:?}"
                     );
                     let nla = &nla.context(err_msg.clone())?;
                     nlas.push(Nl80211IfaceFrameType::parse(nla)?);
@@ -1386,15 +1346,13 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nl80211Attr {
             }
             NL80211_ATTR_MAX_CSA_COUNTERS => {
                 Self::MaxCsaCounters(parse_u8(payload).context(format!(
-                    "Invalid NL80211_ATTR_MAX_CSA_COUNTERS {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_MAX_CSA_COUNTERS {payload:?}"
                 ))?)
             }
             NL80211_ATTR_WIPHY_SELF_MANAGED_REG => Self::WiphySelfManagedReg,
             NL80211_ATTR_SCHED_SCAN_MAX_REQS => {
                 Self::SchedScanMaxReqs(parse_u32(payload).context(format!(
-                    "Invalid NL80211_ATTR_SCHED_SCAN_MAX_REQS {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_SCHED_SCAN_MAX_REQS {payload:?}"
                 ))?)
             }
             NL80211_ATTR_IFTYPE_EXT_CAPA => {
@@ -1415,14 +1373,12 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nl80211Attr {
             }
             NL80211_ATTR_MAX_NUM_AKM_SUITES => {
                 Self::MaxNumAkmSuites(parse_u16(payload).context(format!(
-                    "Invalid NL80211_ATTR_MAX_NUM_AKM_SUITES {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_MAX_NUM_AKM_SUITES {payload:?}"
                 ))?)
             }
             NL80211_ATTR_MAX_HW_TIMESTAMP_PEERS => Self::MaxHwTimestampPeers(
                 parse_u16(payload).context(format!(
-                    "Invalid NL80211_ATTR_MAX_HW_TIMESTAMP_PEERS {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_MAX_HW_TIMESTAMP_PEERS {payload:?}"
                 ))?,
             ),
             NL80211_ATTR_SCAN_SSIDS => {
@@ -1433,22 +1389,19 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nl80211Attr {
             }
             NL80211_ATTR_MEASUREMENT_DURATION => {
                 let err_msg = format!(
-                    "Invalid NL80211_ATTR_MEASUREMENT_DURATION value {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_MEASUREMENT_DURATION value {payload:?}"
                 );
                 Self::MeasurementDuration(parse_u16(payload).context(err_msg)?)
             }
             NL80211_ATTR_SCHED_SCAN_INTERVAL => {
                 let err_msg = format!(
-                    "Invalid NL80211_ATTR_SCHED_SCAN_INTERVAL value {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_SCHED_SCAN_INTERVAL value {payload:?}"
                 );
                 Self::SchedScanInterval(parse_u32(payload).context(err_msg)?)
             }
             NL80211_ATTR_SCHED_SCAN_DELAY => {
                 let err_msg = format!(
-                    "Invalid NL80211_ATTR_SCHED_SCAN_DELAY value {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_SCHED_SCAN_DELAY value {payload:?}"
                 );
                 Self::SchedScanDelay(parse_u32(payload).context(err_msg)?)
             }
@@ -1457,8 +1410,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nl80211Attr {
             ),
             NL80211_ATTR_SCHED_SCAN_MATCH => {
                 let err_msg = format!(
-                    "Invalid NL80211_ATTR_SCHED_SCAN_MATCH value {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_SCHED_SCAN_MATCH value {payload:?}"
                 );
                 let mut nlas = Vec::new();
                 for nla in NlasIterator::new(payload) {
@@ -1469,8 +1421,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nl80211Attr {
             }
             NL80211_ATTR_SCHED_SCAN_PLANS => {
                 let err_msg = format!(
-                    "Invalid NL80211_ATTR_SCHED_SCAN_PLANS value {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_SCHED_SCAN_PLANS value {payload:?}"
                 );
                 let mut nlas = Vec::new();
                 for nla in NlasIterator::new(payload) {

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -31,10 +31,7 @@ pub(crate) fn get_bit(data: &[u8], pos: usize) -> bool {
     let index: usize = pos / 8;
     let bit_pos: usize = pos % 8;
     if data.len() < index {
-        panic!(
-            "BUG: get_bit(): out of index: got data {:?} pos {pos}",
-            data
-        );
+        panic!("BUG: get_bit(): out of index: got data {data:?} pos {pos}");
     }
     (data[index] & 1u8 << bit_pos) >= 1
 }
@@ -59,7 +56,7 @@ pub(crate) fn get_bits_as_u8(data: &[u8], start: usize, end: usize) -> u8 {
 
 pub(crate) fn parse_u16_le(payload: &[u8]) -> Result<u16, DecodeError> {
     if payload.len() < 2 {
-        return Err(format!("Invalid payload for u16: {:?}", payload).into());
+        return Err(format!("Invalid payload for u16: {payload:?}").into());
     }
     Ok(u16::from_le_bytes([payload[0], payload[1]]))
 }

--- a/src/element.rs
+++ b/src/element.rs
@@ -272,8 +272,7 @@ impl<T: AsRef<[u8]> + ?Sized> Parseable<T> for Nl80211ElementCountry {
         if buf.len() < 6 {
             return Err(format!(
                 "Buffer for Nl80211ElementCountry is smaller \
-                than mandatory 6 byte: {:?}",
-                buf
+                than mandatory 6 byte: {buf:?}"
             )
             .into());
         }
@@ -299,7 +298,7 @@ impl<T: AsRef<[u8]> + ?Sized> Parseable<T> for Nl80211ElementCountry {
 
 impl Emitable for Nl80211ElementCountry {
     fn buffer_len(&self) -> usize {
-        (self.triplets.len() * 3 + 3 + 1) / 2 * 2
+        (self.triplets.len() * 3 + 3).div_ceil(2) * 2
     }
 
     fn emit(&self, buffer: &mut [u8]) {
@@ -381,8 +380,7 @@ impl Nl80211ElementCountryTriplet {
         if payload.len() != 3 {
             return Err(format!(
                 "Invalid buffer for Nl80211ElementCountryTriplet, \
-                expecting [u8;3], but got {:?}",
-                payload
+                expecting [u8;3], but got {payload:?}"
             )
             .into());
         }

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -54,10 +54,7 @@ impl Nl80211Handle {
         Nl80211Error,
     > {
         self.handle.request(message).await.map_err(|e| {
-            Nl80211Error::RequestFailed(format!(
-                "BUG: Request failed with {}",
-                e
-            ))
+            Nl80211Error::RequestFailed(format!("BUG: Request failed with {e}"))
         })
     }
 }

--- a/src/iface/combination.rs
+++ b/src/iface/combination.rs
@@ -202,8 +202,7 @@ where
         index: u16,
     ) -> Result<Self, DecodeError> {
         let payload = buf.value();
-        let err_msg =
-            format!("Invalid NL80211_IFACE_COMB_LIMITS {:?}", payload);
+        let err_msg = format!("Invalid NL80211_IFACE_COMB_LIMITS {payload:?}");
         let mut attributes = Vec::new();
         for nla in NlasIterator::new(payload) {
             let nla = &nla.context(err_msg.clone())?;

--- a/src/iface/handle.rs
+++ b/src/iface/handle.rs
@@ -1,8 +1,30 @@
 // SPDX-License-Identifier: MIT
 
-use crate::{Nl80211Handle, Nl80211InterfaceGetRequest};
+use crate::{
+    Nl80211Attr, Nl80211AttrsBuilder, Nl80211Handle, Nl80211InterfaceGetRequest,
+};
+
+use super::{Nl80211InterfaceSetRequest, Nl80211InterfaceType};
 
 pub struct Nl80211InterfaceHandle(Nl80211Handle);
+
+#[derive(Debug)]
+pub struct Nl80211Interface;
+
+impl Nl80211Interface {
+    /// Change properties of the interface
+    pub fn new(if_index: u32) -> Nl80211AttrsBuilder<Self> {
+        Nl80211AttrsBuilder::<Self>::new().if_index(if_index)
+    }
+}
+
+impl Nl80211AttrsBuilder<Nl80211Interface> {
+    /// Change the interface type
+    /// (equivalent to `iw dev type <type>`)
+    pub fn interface_type(self, r#type: Nl80211InterfaceType) -> Self {
+        self.replace(Nl80211Attr::IfType(r#type))
+    }
+}
 
 impl Nl80211InterfaceHandle {
     pub fn new(handle: Nl80211Handle) -> Self {
@@ -13,5 +35,13 @@ impl Nl80211InterfaceHandle {
     /// (equivalent to `iw dev`)
     pub fn get(&mut self) -> Nl80211InterfaceGetRequest {
         Nl80211InterfaceGetRequest::new(self.0.clone())
+    }
+
+    /// Set wireless interfaces attributes
+    pub fn set(
+        &mut self,
+        attributes: Vec<Nl80211Attr>,
+    ) -> Nl80211InterfaceSetRequest {
+        Nl80211InterfaceSetRequest::new(self.0.clone(), attributes)
     }
 }

--- a/src/iface/mod.rs
+++ b/src/iface/mod.rs
@@ -4,13 +4,16 @@ mod combination;
 mod get;
 mod handle;
 mod iface_type;
+mod set;
 
 pub use self::combination::{
     Nl80211IfaceComb, Nl80211IfaceCombAttribute, Nl80211IfaceCombLimit,
     Nl80211IfaceCombLimitAttribute,
 };
 pub use self::get::Nl80211InterfaceGetRequest;
+pub use self::handle::Nl80211Interface;
 pub use self::handle::Nl80211InterfaceHandle;
 pub use self::iface_type::Nl80211InterfaceType;
+pub use self::set::Nl80211InterfaceSetRequest;
 
 pub(crate) use self::iface_type::Nl80211InterfaceTypes;

--- a/src/iface/set.rs
+++ b/src/iface/set.rs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+
+use futures::TryStream;
+use netlink_packet_core::{NLM_F_ACK, NLM_F_REQUEST};
+use netlink_packet_generic::GenlMessage;
+
+use crate::{
+    nl80211_execute, Nl80211Attr, Nl80211Command, Nl80211Error, Nl80211Handle,
+    Nl80211Message,
+};
+
+pub struct Nl80211InterfaceSetRequest {
+    handle: Nl80211Handle,
+    attributes: Vec<Nl80211Attr>,
+}
+
+impl Nl80211InterfaceSetRequest {
+    pub(crate) fn new(
+        handle: Nl80211Handle,
+        attributes: Vec<Nl80211Attr>,
+    ) -> Self {
+        Self { handle, attributes }
+    }
+
+    pub async fn execute(
+        self,
+    ) -> impl TryStream<Ok = GenlMessage<Nl80211Message>, Error = Nl80211Error>
+    {
+        let Nl80211InterfaceSetRequest {
+            mut handle,
+            attributes,
+        } = self;
+
+        let nl80211_msg = Nl80211Message {
+            cmd: Nl80211Command::SetInterface,
+            // TODO: Should this be open to every attribute or restricted to
+            // Interface ATTR?
+            attributes: dbg!(attributes),
+        };
+        // TODO: is the in iw dev set
+        // I don't understand the correct seting of flags yet. In case of set
+        // `iw` does not set any flag, but here NLM_F_REQUEST is always
+        // set. Curentliy infreadead.org libnl documentation website is
+        // down. These are the same flags as in scan.rs
+        let flags = NLM_F_REQUEST | NLM_F_ACK;
+
+        nl80211_execute(&mut handle, nl80211_msg, flags).await
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,8 +43,8 @@ pub use self::frame_type::{Nl80211FrameType, Nl80211IfaceFrameType};
 pub use self::handle::Nl80211Handle;
 pub use self::iface::{
     Nl80211IfaceComb, Nl80211IfaceCombAttribute, Nl80211IfaceCombLimit,
-    Nl80211IfaceCombLimitAttribute, Nl80211InterfaceGetRequest,
-    Nl80211InterfaceHandle, Nl80211InterfaceType,
+    Nl80211IfaceCombLimitAttribute, Nl80211Interface,
+    Nl80211InterfaceGetRequest, Nl80211InterfaceHandle, Nl80211InterfaceType,
 };
 pub use self::message::Nl80211Message;
 pub use self::mlo::Nl80211MloLink;

--- a/src/mlo.rs
+++ b/src/mlo.rs
@@ -52,8 +52,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
         Ok(match buf.kind() {
             NL80211_ATTR_MLO_LINK_ID => {
                 let err_msg = format!(
-                    "Invalid NL80211_ATTR_MLO_LINK_ID value {:?}",
-                    payload
+                    "Invalid NL80211_ATTR_MLO_LINK_ID value {payload:?}"
                 );
                 Self::Id(parse_u8(payload).context(err_msg)?)
             }
@@ -63,8 +62,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                 ret
             } else {
                 return Err(format!(
-                    "Invalid length of NL80211_ATTR_MAC, expected length {} got {:?}",
-                    ETH_ALEN, payload
+                    "Invalid length of NL80211_ATTR_MAC, expected length {ETH_ALEN} got {payload:?}"
                 )
                 .into());
             }),
@@ -104,7 +102,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
         let mut ret = Self::default();
         let payload = buf.value();
         let err_msg =
-            format!("Invalid NL80211_ATTR_MLO_LINKS value {:?}", payload);
+            format!("Invalid NL80211_ATTR_MLO_LINKS value {payload:?}");
         for nla in NlasIterator::new(payload) {
             let nla = &nla.context(err_msg.clone())?;
             match Nl80211MloLinkNla::parse(nla).context(err_msg.clone())? {

--- a/src/scan/bss_info.rs
+++ b/src/scan/bss_info.rs
@@ -268,20 +268,17 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
             }
             NL80211_BSS_TSF => {
                 let err_msg =
-                    format!("Invalid NL80211_BSS_TSF value {:?}", payload);
+                    format!("Invalid NL80211_BSS_TSF value {payload:?}");
                 Self::Tsf(parse_u64(payload).context(err_msg)?)
             }
             NL80211_BSS_FREQUENCY => {
-                let err_msg = format!(
-                    "Invalid NL80211_BSS_FREQUENCY value {:?}",
-                    payload
-                );
+                let err_msg =
+                    format!("Invalid NL80211_BSS_FREQUENCY value {payload:?}");
                 Self::Frequency(parse_u32(payload).context(err_msg)?)
             }
             NL80211_BSS_BEACON_INTERVAL => {
                 let err_msg = format!(
-                    "Invalid NL80211_BSS_BEACON_INTERVAL value {:?}",
-                    payload
+                    "Invalid NL80211_BSS_BEACON_INTERVAL value {payload:?}"
                 );
                 Self::BeaconInterval(parse_u16(payload).context(err_msg)?)
             }
@@ -298,58 +295,48 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                 Nl80211Elements::parse(payload)?.into(),
             ),
             NL80211_BSS_SIGNAL_MBM => {
-                let err_msg = format!(
-                    "Invalid NL80211_BSS_SIGNAL_MBM value {:?}",
-                    payload
-                );
+                let err_msg =
+                    format!("Invalid NL80211_BSS_SIGNAL_MBM value {payload:?}");
                 Self::SignalMbm(i32::from_ne_bytes(
                     payload.try_into().context(err_msg)?,
                 ))
             }
             NL80211_BSS_SIGNAL_UNSPEC => {
                 let err_msg = format!(
-                    "Invalid NL80211_BSS_SIGNAL_UNSPEC value {:?}",
-                    payload
+                    "Invalid NL80211_BSS_SIGNAL_UNSPEC value {payload:?}"
                 );
                 Self::SignalUnspec(parse_u8(payload).context(err_msg)?)
             }
             NL80211_BSS_STATUS => {
                 let err_msg =
-                    format!("Invalid NL80211_BSS_STATUS value {:?}", payload);
+                    format!("Invalid NL80211_BSS_STATUS value {payload:?}");
                 Self::Status(parse_u32(payload).context(err_msg)?)
             }
             NL80211_BSS_SEEN_MS_AGO => {
                 let err_msg = format!(
-                    "Invalid NL80211_BSS_SEEN_MS_AGO value {:?}",
-                    payload
+                    "Invalid NL80211_BSS_SEEN_MS_AGO value {payload:?}"
                 );
                 Self::SeenMsAgo(parse_u32(payload).context(err_msg)?)
             }
             NL80211_BSS_CHAN_WIDTH => {
-                let err_msg = format!(
-                    "Invalid NL80211_BSS_CHAN_WIDTH value {:?}",
-                    payload
-                );
+                let err_msg =
+                    format!("Invalid NL80211_BSS_CHAN_WIDTH value {payload:?}");
                 Self::ChanWidth(parse_u32(payload).context(err_msg)?)
             }
             NL80211_BSS_BEACON_TSF => {
-                let err_msg = format!(
-                    "Invalid NL80211_BSS_BEACON_TSF value {:?}",
-                    payload
-                );
+                let err_msg =
+                    format!("Invalid NL80211_BSS_BEACON_TSF value {payload:?}");
                 Self::BeaconTsf(parse_u64(payload).context(err_msg)?)
             }
             NL80211_BSS_LAST_SEEN_BOOTTIME => {
                 let err_msg = format!(
-                    "Invalid NL80211_BSS_LAST_SEEN_BOOTTIME value {:?}",
-                    payload
+                    "Invalid NL80211_BSS_LAST_SEEN_BOOTTIME value {payload:?}"
                 );
                 Self::LastSeenBootTime(parse_u64(payload).context(err_msg)?)
             }
             NL80211_BSS_FREQUENCY_OFFSET => {
                 Self::FrequencyOffset(parse_u32(payload).context(format!(
-                    "Invalid NL80211_BSS_FREQUENCY_OFFSET {:?}",
-                    payload
+                    "Invalid NL80211_BSS_FREQUENCY_OFFSET {payload:?}"
                 ))?)
             }
             NL80211_BSS_USE_FOR => {

--- a/src/scan/schedule.rs
+++ b/src/scan/schedule.rs
@@ -150,15 +150,13 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
         Ok(match buf.kind() {
             NL80211_SCHED_SCAN_MATCH_ATTR_SSID => {
                 let err_msg = format!(
-                    "Invalid NL80211_SCHED_SCAN_MATCH_ATTR_SSID value {:?}",
-                    payload
+                    "Invalid NL80211_SCHED_SCAN_MATCH_ATTR_SSID value {payload:?}"
                 );
                 Self::Ssid(parse_string(payload).context(err_msg)?)
             }
             NL80211_SCHED_SCAN_MATCH_ATTR_RSSI => {
                 let err_msg = format!(
-                    "Invalid NL80211_SCHED_SCAN_MATCH_ATTR_RSSI value {:?}",
-                    payload
+                    "Invalid NL80211_SCHED_SCAN_MATCH_ATTR_RSSI value {payload:?}"
                 );
                 Self::Rssi(parse_i32(payload).context(err_msg)?)
             }
@@ -228,15 +226,13 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
         Ok(match buf.kind() {
             NL80211_SCHED_SCAN_PLAN_INTERVAL => {
                 let err_msg = format!(
-                    "Invalid NL80211_SCHED_SCAN_PLAN_INTERVAL value {:?}",
-                    payload
+                    "Invalid NL80211_SCHED_SCAN_PLAN_INTERVAL value {payload:?}"
                 );
                 Self::Interval(parse_u32(payload).context(err_msg)?)
             }
             NL80211_SCHED_SCAN_PLAN_ITERATIONS => {
                 let err_msg = format!(
-                    "Invalid NL80211_SCHED_SCAN_PLAN_ITERATIONS value {:?}",
-                    payload
+                    "Invalid NL80211_SCHED_SCAN_PLAN_ITERATIONS value {payload:?}"
                 );
                 Self::Iterations(parse_u32(payload).context(err_msg)?)
             }

--- a/src/station/rate_info.rs
+++ b/src/station/rate_info.rs
@@ -180,16 +180,13 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
         Ok(match buf.kind() {
             NL80211_RATE_INFO_BITRATE => {
                 let err_msg = format!(
-                    "Invalid NL80211_RATE_INFO_BITRATE value {:?}",
-                    payload
+                    "Invalid NL80211_RATE_INFO_BITRATE value {payload:?}"
                 );
                 Self::Bitrate(parse_u16(payload).context(err_msg)?)
             }
             NL80211_RATE_INFO_MCS => {
-                let err_msg = format!(
-                    "Invalid NL80211_RATE_INFO_MCS value {:?}",
-                    payload
-                );
+                let err_msg =
+                    format!("Invalid NL80211_RATE_INFO_MCS value {payload:?}");
                 Self::Mcs(parse_u8(payload).context(err_msg)?)
             }
             NL80211_RATE_INFO_1_MHZ_WIDTH => Self::MhzWidth(1),
@@ -207,103 +204,89 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
             NL80211_RATE_INFO_SHORT_GI => Self::ShortGi,
             NL80211_RATE_INFO_BITRATE32 => {
                 let err_msg = format!(
-                    "Invalid NL80211_RATE_INFO_BITRATE32 value {:?}",
-                    payload
+                    "Invalid NL80211_RATE_INFO_BITRATE32 value {payload:?}"
                 );
                 Self::Bitrate32(parse_u32(payload).context(err_msg)?)
             }
             NL80211_RATE_INFO_VHT_MCS => {
                 let err_msg = format!(
-                    "Invalid NL80211_RATE_INFO_VHT_MCS value {:?}",
-                    payload
+                    "Invalid NL80211_RATE_INFO_VHT_MCS value {payload:?}"
                 );
                 Self::VhtMcs(parse_u8(payload).context(err_msg)?)
             }
             NL80211_RATE_INFO_VHT_NSS => {
                 let err_msg = format!(
-                    "Invalid NL80211_RATE_INFO_VHT_NSS value {:?}",
-                    payload
+                    "Invalid NL80211_RATE_INFO_VHT_NSS value {payload:?}"
                 );
                 Self::VhtNss(parse_u8(payload).context(err_msg)?)
             }
             NL80211_RATE_INFO_HE_MCS => {
                 let err_msg = format!(
-                    "Invalid NL80211_RATE_INFO_HE_MCS value {:?}",
-                    payload
+                    "Invalid NL80211_RATE_INFO_HE_MCS value {payload:?}"
                 );
                 Self::HeMcs(parse_u8(payload).context(err_msg)?)
             }
             NL80211_RATE_INFO_HE_NSS => {
                 let err_msg = format!(
-                    "Invalid NL80211_RATE_INFO_HE_NSS value {:?}",
-                    payload
+                    "Invalid NL80211_RATE_INFO_HE_NSS value {payload:?}"
                 );
                 Self::HeNss(parse_u8(payload).context(err_msg)?)
             }
             NL80211_RATE_INFO_HE_GI => {
                 //
                 let err_msg = format!(
-                    "Invalid NL80211_RATE_INFO_HE_GI value {:?}",
-                    payload
+                    "Invalid NL80211_RATE_INFO_HE_GI value {payload:?}"
                 );
                 Self::HeGi(parse_u8(payload).context(err_msg)?.into())
             }
             NL80211_RATE_INFO_HE_DCM => {
                 let err_msg = format!(
-                    "Invalid NL80211_RATE_INFO_HE_DCM value {:?}",
-                    payload
+                    "Invalid NL80211_RATE_INFO_HE_DCM value {payload:?}"
                 );
                 Self::HeDcm(parse_u8(payload).context(err_msg)?)
             }
             NL80211_RATE_INFO_HE_RU_ALLOC => {
                 //
                 let err_msg = format!(
-                    "Invalid NL80211_RATE_INFO_HE_RU_ALLOC value {:?}",
-                    payload
+                    "Invalid NL80211_RATE_INFO_HE_RU_ALLOC value {payload:?}"
                 );
                 Self::HeRuAlloc(parse_u8(payload).context(err_msg)?.into())
             }
             NL80211_RATE_INFO_S1G_MCS => {
                 let err_msg = format!(
-                    "Invalid NL80211_RATE_INFO_S1G_MCS value {:?}",
-                    payload
+                    "Invalid NL80211_RATE_INFO_S1G_MCS value {payload:?}"
                 );
                 Self::S1gMcs(parse_u8(payload).context(err_msg)?)
             }
             NL80211_RATE_INFO_S1G_NSS => {
                 let err_msg = format!(
-                    "Invalid NL80211_RATE_INFO_S1G_NSS value {:?}",
-                    payload
+                    "Invalid NL80211_RATE_INFO_S1G_NSS value {payload:?}"
                 );
                 Self::S1gNss(parse_u8(payload).context(err_msg)?)
             }
             NL80211_RATE_INFO_EHT_MCS => {
                 let err_msg = format!(
-                    "Invalid NL80211_RATE_INFO_EHT_MCS value {:?}",
-                    payload
+                    "Invalid NL80211_RATE_INFO_EHT_MCS value {payload:?}"
                 );
                 Self::EhtMcs(parse_u8(payload).context(err_msg)?)
             }
             NL80211_RATE_INFO_EHT_NSS => {
                 let err_msg = format!(
-                    "Invalid NL80211_RATE_INFO_EHT_NSS value {:?}",
-                    payload
+                    "Invalid NL80211_RATE_INFO_EHT_NSS value {payload:?}"
                 );
                 Self::EhtNss(parse_u8(payload).context(err_msg)?)
             }
             NL80211_RATE_INFO_EHT_GI => {
                 //
                 let err_msg = format!(
-                    "Invalid NL80211_RATE_INFO_EHT_GI value {:?}",
-                    payload
+                    "Invalid NL80211_RATE_INFO_EHT_GI value {payload:?}"
                 );
                 Self::EhtGi(parse_u8(payload).context(err_msg)?.into())
             }
             NL80211_RATE_INFO_EHT_RU_ALLOC => {
                 //
                 let err_msg = format!(
-                    "Invalid NL80211_RATE_INFO_EHT_RU_ALLOC value {:?}",
-                    payload
+                    "Invalid NL80211_RATE_INFO_EHT_RU_ALLOC value {payload:?}"
                 );
                 Self::EhtRuAlloc(parse_u8(payload).context(err_msg)?.into())
             }

--- a/src/station/station_info.rs
+++ b/src/station/station_info.rs
@@ -368,57 +368,47 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
         Ok(match buf.kind() {
             NL80211_STA_INFO_INACTIVE_TIME => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_INACTIVE_TIME value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_INACTIVE_TIME value {payload:?}"
                 );
                 Self::InactiveTime(parse_u32(payload).context(err_msg)?)
             }
             NL80211_STA_INFO_RX_BYTES => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_RX_BYTES value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_RX_BYTES value {payload:?}"
                 );
                 Self::RxBytes(parse_u32(payload).context(err_msg)?)
             }
             NL80211_STA_INFO_TX_BYTES => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_TX_BYTES value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_TX_BYTES value {payload:?}"
                 );
                 Self::TxBytes(parse_u32(payload).context(err_msg)?)
             }
             NL80211_STA_INFO_LLID => {
-                let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_LLID value {:?}",
-                    payload
-                );
+                let err_msg =
+                    format!("Invalid NL80211_STA_INFO_LLID value {payload:?}");
                 Self::Llid(parse_u16(payload).context(err_msg)?)
             }
             NL80211_STA_INFO_PLID => {
-                let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_PLID value {:?}",
-                    payload
-                );
+                let err_msg =
+                    format!("Invalid NL80211_STA_INFO_PLID value {payload:?}");
                 Self::Plid(parse_u16(payload).context(err_msg)?)
             }
             NL80211_STA_INFO_PLINK_STATE => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_PLINK_STATE value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_PLINK_STATE value {payload:?}"
                 );
                 Self::PeerLinkState(parse_u8(payload).context(err_msg)?.into())
             }
             NL80211_STA_INFO_SIGNAL => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_SIGNAL value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_SIGNAL value {payload:?}"
                 );
                 Self::Signal(parse_u8(payload).context(err_msg)? as i8)
             }
             NL80211_STA_INFO_TX_BITRATE => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_TX_BITRATE value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_TX_BITRATE value {payload:?}"
                 );
                 let mut nlas = Vec::new();
                 for nla in NlasIterator::new(payload) {
@@ -431,43 +421,37 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
             }
             NL80211_STA_INFO_RX_PACKETS => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_RX_PACKETS value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_RX_PACKETS value {payload:?}"
                 );
                 Self::RxPackets(parse_u32(payload).context(err_msg)?)
             }
             NL80211_STA_INFO_TX_PACKETS => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_TX_PACKETS value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_TX_PACKETS value {payload:?}"
                 );
                 Self::TxPackets(parse_u32(payload).context(err_msg)?)
             }
             NL80211_STA_INFO_TX_RETRIES => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_TX_RETRIES value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_TX_RETRIES value {payload:?}"
                 );
                 Self::TxRetries(parse_u32(payload).context(err_msg)?)
             }
             NL80211_STA_INFO_TX_FAILED => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_TX_FAILED value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_TX_FAILED value {payload:?}"
                 );
                 Self::TxFailed(parse_u32(payload).context(err_msg)?)
             }
             NL80211_STA_INFO_SIGNAL_AVG => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_SIGNAL_AVG value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_SIGNAL_AVG value {payload:?}"
                 );
                 Self::SignalAvg(parse_u8(payload).context(err_msg)? as i8)
             }
             NL80211_STA_INFO_RX_BITRATE => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_RX_BITRATE value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_RX_BITRATE value {payload:?}"
                 );
                 let mut nlas = Vec::new();
                 for nla in NlasIterator::new(payload) {
@@ -480,8 +464,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
             }
             NL80211_STA_INFO_BSS_PARAM => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_BSS_PARAM value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_BSS_PARAM value {payload:?}"
                 );
                 let mut nlas = Vec::new();
                 for nla in NlasIterator::new(payload) {
@@ -495,16 +478,14 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
             }
             NL80211_STA_INFO_CONNECTED_TIME => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_CONNECTED_TIME value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_CONNECTED_TIME value {payload:?}"
                 );
                 Self::ConnectedTime(parse_u32(payload).context(err_msg)?)
             }
             NL80211_STA_INFO_STA_FLAGS => {
                 Self::StationFlags(if payload.len() == 8 {
                     let err_msg = format!(
-                        "Invalid NL80211_STA_INFO_STA_FLAGS value {:?}",
-                        payload
+                        "Invalid NL80211_STA_INFO_STA_FLAGS value {payload:?}"
                     );
                     let mask =
                         parse_u32(&payload[0..4]).context(err_msg.clone())?;
@@ -523,15 +504,13 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
             }
             NL80211_STA_INFO_BEACON_LOSS => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_BEACON_LOSS value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_BEACON_LOSS value {payload:?}"
                 );
                 Self::BeaconLoss(parse_u32(payload).context(err_msg)?)
             }
             NL80211_STA_INFO_T_OFFSET => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_T_OFFSET value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_T_OFFSET value {payload:?}"
                 );
                 Self::TimingOffset(i64::from_ne_bytes(
                     payload.try_into().context(err_msg)?,
@@ -539,8 +518,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
             }
             NL80211_STA_INFO_LOCAL_PM => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_LOCAL_PM value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_LOCAL_PM value {payload:?}"
                 );
                 Self::LocalPowerMode(
                     parse_u32(payload).context(err_msg)?.into(),
@@ -548,15 +526,13 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
             }
             NL80211_STA_INFO_PEER_PM => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_PEER_PM value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_PEER_PM value {payload:?}"
                 );
                 Self::PeerPowerMode(parse_u32(payload).context(err_msg)?.into())
             }
             NL80211_STA_INFO_NONPEER_PM => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_NONPEER_PM value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_NONPEER_PM value {payload:?}"
                 );
                 Self::NonPeerPowerMode(
                     parse_u32(payload).context(err_msg)?.into(),
@@ -564,15 +540,13 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
             }
             NL80211_STA_INFO_RX_BYTES64 => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_RX_BYTES64 value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_RX_BYTES64 value {payload:?}"
                 );
                 Self::RxBytes64(parse_u64(payload).context(err_msg)?)
             }
             NL80211_STA_INFO_TX_BYTES64 => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_TX_BYTES64 value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_TX_BYTES64 value {payload:?}"
                 );
                 Self::TxBytes64(parse_u64(payload).context(err_msg)?)
             }
@@ -584,36 +558,31 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
             }
             NL80211_STA_INFO_EXPECTED_THROUGHPUT => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_EXPECTED_THROUGHPUT value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_EXPECTED_THROUGHPUT value {payload:?}"
                 );
                 Self::ExpectedThroughput(parse_u32(payload).context(err_msg)?)
             }
             NL80211_STA_INFO_RX_DROP_MISC => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_RX_DROP_MISC value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_RX_DROP_MISC value {payload:?}"
                 );
                 Self::RxDropMisc(parse_u64(payload).context(err_msg)?)
             }
             NL80211_STA_INFO_BEACON_RX => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_BEACON_RX value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_BEACON_RX value {payload:?}"
                 );
                 Self::BeaconRx(parse_u64(payload).context(err_msg)?)
             }
             NL80211_STA_INFO_BEACON_SIGNAL_AVG => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_BEACON_SIGNAL_AVG value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_BEACON_SIGNAL_AVG value {payload:?}"
                 );
                 Self::BeaconSignalAvg(parse_u8(payload).context(err_msg)? as i8)
             }
             NL80211_STA_INFO_TID_STATS => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_TID_STATS value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_TID_STATS value {payload:?}"
                 );
                 let mut nlas = Vec::new();
                 let _t = NlasIterator::new(payload);
@@ -628,71 +597,61 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
             }
             NL80211_STA_INFO_RX_DURATION => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_RX_DURATION value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_RX_DURATION value {payload:?}"
                 );
                 Self::RxDuration(parse_u64(payload).context(err_msg)?)
             }
             NL80211_STA_INFO_ACK_SIGNAL => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_ACK_SIGNAL value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_ACK_SIGNAL value {payload:?}"
                 );
                 Self::AckSignal(parse_u8(payload).context(err_msg)? as i8)
             }
             NL80211_STA_INFO_ACK_SIGNAL_AVG => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_ACK_SIGNAL_AVG value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_ACK_SIGNAL_AVG value {payload:?}"
                 );
                 Self::AckSignalAvg(*payload.first().context(err_msg)? as i8)
             }
             NL80211_STA_INFO_RX_MPDUS => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_RX_MPDUS value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_RX_MPDUS value {payload:?}"
                 );
                 Self::RxMpdus(parse_u32(payload).context(err_msg)?)
             }
             NL80211_STA_INFO_FCS_ERROR_COUNT => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_FCS_ERROR_COUNT value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_FCS_ERROR_COUNT value {payload:?}"
                 );
                 Self::FcsErrorCount(parse_u32(payload).context(err_msg)?)
             }
             NL80211_STA_INFO_CONNECTED_TO_GATE => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_CONNECTED_TO_GATE value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_CONNECTED_TO_GATE value {payload:?}"
                 );
                 Self::ConnectedToGate(parse_u8(payload).context(err_msg)? == 1)
             }
             NL80211_STA_INFO_TX_DURATION => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_TX_DURATION value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_TX_DURATION value {payload:?}"
                 );
                 Self::TxDuration(parse_u64(payload).context(err_msg)?)
             }
             NL80211_STA_INFO_AIRTIME_WEIGHT => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_AIRTIME_WEIGHT value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_AIRTIME_WEIGHT value {payload:?}"
                 );
                 Self::AirtimeWeight(parse_u16(payload).context(err_msg)?)
             }
             NL80211_STA_INFO_AIRTIME_LINK_METRIC => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_AIRTIME_LINK_METRIC value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_AIRTIME_LINK_METRIC value {payload:?}"
                 );
                 Self::AirtimeLinkMetric(parse_u16(payload).context(err_msg)?)
             }
             NL80211_STA_INFO_ASSOC_AT_BOOTTIME => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_ASSOC_AT_BOOTTIME value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_ASSOC_AT_BOOTTIME value {payload:?}"
                 );
                 Self::AssociationAtBoottime(
                     parse_u64(payload).context(err_msg)?,
@@ -700,8 +659,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
             }
             NL80211_STA_INFO_CONNECTED_TO_AS => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_INFO_CONNECTED_TO_AS value {:?}",
-                    payload
+                    "Invalid NL80211_STA_INFO_CONNECTED_TO_AS value {payload:?}"
                 );
                 Self::ConnectedToAuthServer(
                     parse_u8(payload).context(err_msg)? == 1,
@@ -842,15 +800,13 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
             NL80211_STA_BSS_PARAM_SHORT_SLOT_TIME => Self::ShortSlotTime,
             NL80211_STA_BSS_PARAM_DTIM_PERIOD => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_BSS_PARAM_DTIM_PERIOD value {:?}",
-                    payload
+                    "Invalid NL80211_STA_BSS_PARAM_DTIM_PERIOD value {payload:?}"
                 );
                 Self::DtimPeriod(parse_u8(payload).context(err_msg)?)
             }
             NL80211_STA_BSS_PARAM_BEACON_INTERVAL => {
                 let err_msg = format!(
-                    "Invalid NL80211_STA_BSS_PARAM_BEACON_INTERVAL value {:?}",
-                    payload
+                    "Invalid NL80211_STA_BSS_PARAM_BEACON_INTERVAL value {payload:?}"
                 );
                 Self::BeaconInterval(parse_u16(payload).context(err_msg)?)
             }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -31,7 +31,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = buf.value();
         let err_msg =
-            format!("Invalid NestedNl80211TidStats value {:?}", payload);
+            format!("Invalid NestedNl80211TidStats value {payload:?}");
         let mut nlas = Vec::new();
 
         for nla in NlasIterator::new(payload) {
@@ -107,36 +107,31 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
         Ok(match buf.kind() {
             NL80211_TID_STATS_RX_MSDU => {
                 let err_msg = format!(
-                    "Invalid NL80211_TID_STATS_RX_MSDU value: {:?}",
-                    payload
+                    "Invalid NL80211_TID_STATS_RX_MSDU value: {payload:?}"
                 );
                 Self::RxMsdu(parse_u64(payload).context(err_msg)?)
             }
             NL80211_TID_STATS_TX_MSDU => {
                 let err_msg = format!(
-                    "Invalid NL80211_TID_STATS_TX_MSDU value: {:?}",
-                    payload
+                    "Invalid NL80211_TID_STATS_TX_MSDU value: {payload:?}"
                 );
                 Self::TxMsdu(parse_u64(payload).context(err_msg)?)
             }
             NL80211_TID_STATS_TX_MSDU_RETRIES => {
                 let err_msg = format!(
-                    "Invalid NL80211_TID_STATS_TX_MSDU_RETRIES value: {:?}",
-                    payload
+                    "Invalid NL80211_TID_STATS_TX_MSDU_RETRIES value: {payload:?}"
                 );
                 Self::TxMsduRetries(parse_u64(payload).context(err_msg)?)
             }
             NL80211_TID_STATS_TX_MSDU_FAILED => {
                 let err_msg = format!(
-                    "Invalid NL80211_TID_STATS_TX_MSDU_FAILED value: {:?}",
-                    payload
+                    "Invalid NL80211_TID_STATS_TX_MSDU_FAILED value: {payload:?}"
                 );
                 Self::TxMsduFailed(parse_u64(payload).context(err_msg)?)
             }
             NL80211_TID_STATS_TXQ_STATS => {
                 let err_msg = format!(
-                    "Invalid NL80211_TID_STATS_TXQ_STATS value {:?}",
-                    payload
+                    "Invalid NL80211_TID_STATS_TXQ_STATS value {payload:?}"
                 );
                 let mut nlas = Vec::new();
                 for nla in NlasIterator::new(payload) {
@@ -242,78 +237,67 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
         Ok(match buf.kind() {
             NL80211_TXQ_STATS_BACKLOG_BYTES => {
                 let err_msg = format!(
-                    "Invalid NL80211_TXQ_STATS_BACKLOG_BYTES value {:?}",
-                    payload
+                    "Invalid NL80211_TXQ_STATS_BACKLOG_BYTES value {payload:?}"
                 );
                 Self::BacklogBytes(parse_u32(payload).context(err_msg)?)
             }
             NL80211_TXQ_STATS_BACKLOG_PACKETS => {
                 let err_msg = format!(
-                    "Invalid NL80211_TXQ_STATS_BACKLOG_PACKETS value: {:?}",
-                    payload
+                    "Invalid NL80211_TXQ_STATS_BACKLOG_PACKETS value: {payload:?}"
                 );
                 Self::BacklogPackets(parse_u32(payload).context(err_msg)?)
             }
             NL80211_TXQ_STATS_FLOWS => {
                 let err_msg = format!(
-                    "Invalid NL80211_TXQ_STATS_FLOWS value: {:?}",
-                    payload
+                    "Invalid NL80211_TXQ_STATS_FLOWS value: {payload:?}"
                 );
                 Self::Flows(parse_u32(payload).context(err_msg)?)
             }
             NL80211_TXQ_STATS_DROPS => {
                 let err_msg = format!(
-                    "Invalid NL80211_TXQ_STATS_DROPS value: {:?}",
-                    payload
+                    "Invalid NL80211_TXQ_STATS_DROPS value: {payload:?}"
                 );
                 Self::Drops(parse_u32(payload).context(err_msg)?)
             }
             NL80211_TXQ_STATS_ECN_MARKS => {
                 let err_msg = format!(
-                    "Invalid NL80211_TXQ_STATS_ECN_MARKS value: {:?}",
-                    payload
+                    "Invalid NL80211_TXQ_STATS_ECN_MARKS value: {payload:?}"
                 );
                 Self::EcnMarks(parse_u32(payload).context(err_msg)?)
             }
             NL80211_TXQ_STATS_OVERLIMIT => {
                 let err_msg = format!(
-                    "Invalid NL80211_TXQ_STATS_OVERLIMIT value: {:?}",
-                    payload
+                    "Invalid NL80211_TXQ_STATS_OVERLIMIT value: {payload:?}"
                 );
                 Self::Overlimit(parse_u32(payload).context(err_msg)?)
             }
             NL80211_TXQ_STATS_OVERMEMORY => {
                 let err_msg = format!(
-                    "Invalid NL80211_TXQ_STATS_OVERMEMORY value: {:?}",
-                    payload
+                    "Invalid NL80211_TXQ_STATS_OVERMEMORY value: {payload:?}"
                 );
                 Self::Overmemory(parse_u32(payload).context(err_msg)?)
             }
             NL80211_TXQ_STATS_COLLISIONS => {
                 let err_msg = format!(
-                    "Invalid NL80211_TXQ_STATS_COLLISIONS value: {:?}",
-                    payload
+                    "Invalid NL80211_TXQ_STATS_COLLISIONS value: {payload:?}"
                 );
                 Self::Collisions(parse_u32(payload).context(err_msg)?)
             }
             NL80211_TXQ_STATS_TX_BYTES => {
                 let err_msg = format!(
-                    "Invalid NL80211_TXQ_STATS_TX_BYTES value: {:?}",
-                    payload
+                    "Invalid NL80211_TXQ_STATS_TX_BYTES value: {payload:?}"
                 );
                 Self::TxBytes(parse_u32(payload).context(err_msg)?)
             }
             NL80211_TXQ_STATS_TX_PACKETS => {
                 let err_msg = format!(
-                    "Invalid NL80211_TXQ_STATS_TX_PACKETS value: {:?}",
-                    payload
+                    "Invalid NL80211_TXQ_STATS_TX_PACKETS value: {payload:?}"
                 );
                 Self::TxPackets(parse_u32(payload).context(err_msg)?)
             }
             NL80211_TXQ_STATS_MAX_FLOWS => {
                 let err_msg = format!(
-                    "Invalid NL80211_TXQ_STATS_MAX_FLOWS value: {:?}",
-                    payload
+                    "Invalid NL80211_TXQ_STATS_MAX_FLOWS value: {payload:?}"
                 );
                 Self::MaxFlows(parse_u32(payload).context(err_msg)?)
             }

--- a/src/wiphy/band.rs
+++ b/src/wiphy/band.rs
@@ -71,7 +71,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nl80211Band {
         let mut nlas = Vec::new();
         for nla in NlasIterator::new(payload) {
             let err_msg =
-                format!("Invalid NL80211_ATTR_WIPHY_BANDS value {:?}", nla);
+                format!("Invalid NL80211_ATTR_WIPHY_BANDS value {nla:?}");
             let nla = &nla.context(err_msg.clone())?;
             nlas.push(Nl80211BandInfo::parse(nla)?);
         }
@@ -276,8 +276,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
         Ok(match buf.kind() {
             NL80211_BAND_ATTR_FREQS => {
                 let err_msg = format!(
-                    "Invalid NL80211_BAND_ATTR_FREQS value {:?}",
-                    payload
+                    "Invalid NL80211_BAND_ATTR_FREQS value {payload:?}"
                 );
                 let mut nlas = Vec::new();
                 for nla in NlasIterator::new(payload) {
@@ -288,8 +287,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
             }
             NL80211_BAND_ATTR_RATES => {
                 let err_msg = format!(
-                    "Invalid NL80211_BAND_ATTR_RATES value {:?}",
-                    payload
+                    "Invalid NL80211_BAND_ATTR_RATES value {payload:?}"
                 );
                 let mut nlas = Vec::new();
                 for (index, nla) in NlasIterator::new(payload).enumerate() {
@@ -310,15 +308,13 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
             }
             NL80211_BAND_ATTR_HT_AMPDU_FACTOR => {
                 let err_msg = format!(
-                    "Invalid NL80211_BAND_ATTR_HT_AMPDU_FACTOR value {:?}",
-                    payload
+                    "Invalid NL80211_BAND_ATTR_HT_AMPDU_FACTOR value {payload:?}"
                 );
                 Self::HtAmpduFactor(parse_u8(payload).context(err_msg)?)
             }
             NL80211_BAND_ATTR_HT_AMPDU_DENSITY => {
                 let err_msg = format!(
-                    "Invalid NL80211_BAND_ATTR_HT_AMPDU_DENSITY value {:?}",
-                    payload
+                    "Invalid NL80211_BAND_ATTR_HT_AMPDU_DENSITY value {payload:?}"
                 );
                 Self::HtAmpduDensity(parse_u8(payload).context(err_msg)?)
             }
@@ -330,8 +326,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
             }
             NL80211_BAND_ATTR_IFTYPE_DATA => {
                 let err_msg = format!(
-                    "Invalid NL80211_BAND_ATTR_IFTYPE_DATA value {:?}",
-                    payload
+                    "Invalid NL80211_BAND_ATTR_IFTYPE_DATA value {payload:?}"
                 );
                 let mut nlas = Vec::new();
                 for nla in NlasIterator::new(payload) {
@@ -345,15 +340,13 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
             }
             NL80211_BAND_ATTR_EDMG_CHANNELS => {
                 let err_msg = format!(
-                    "Invalid NL80211_BAND_ATTR_EDMG_CHANNELS value {:?}",
-                    payload
+                    "Invalid NL80211_BAND_ATTR_EDMG_CHANNELS value {payload:?}"
                 );
                 Self::EdmgChannels(parse_u8(payload).context(err_msg)?)
             }
             NL80211_BAND_ATTR_EDMG_BW_CONFIG => {
                 let err_msg = format!(
-                    "Invalid NL80211_BAND_ATTR_EDMG_BW_CONFIG value {:?}",
-                    payload
+                    "Invalid NL80211_BAND_ATTR_EDMG_BW_CONFIG value {payload:?}"
                 );
                 Self::EdmgBwConfig(parse_u8(payload).context(err_msg)?)
             }
@@ -714,7 +707,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
         let mut nlas = Vec::new();
         for nla in NlasIterator::new(payload) {
             let err_msg =
-                format!("Invalid NL80211_BAND_ATTR_FREQS value {:?}", nla);
+                format!("Invalid NL80211_BAND_ATTR_FREQS value {nla:?}");
             let nla = &nla.context(err_msg.clone())?;
             nlas.push(Nl80211FrequencyInfo::parse(nla)?);
         }
@@ -984,8 +977,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
         Ok(match buf.kind() {
             NL80211_FREQUENCY_ATTR_FREQ => {
                 Self::Freq(parse_u32(payload).context(format!(
-                    "Invalid NL80211_FREQUENCY_ATTR_FREQ value: {:?}",
-                    payload
+                    "Invalid NL80211_FREQUENCY_ATTR_FREQ value: {payload:?}"
                 ))?)
             }
             NL80211_FREQUENCY_ATTR_DISABLED => Self::Disabled,
@@ -994,23 +986,20 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
             NL80211_FREQUENCY_ATTR_RADAR => Self::Radar,
             NL80211_FREQUENCY_ATTR_MAX_TX_POWER => {
                 Self::MaxTxPower(parse_u32(payload).context(format!(
-                    "Invalid NL80211_FREQUENCY_ATTR_MAX_TX_POWER value: {:?}",
-                    payload
+                    "Invalid NL80211_FREQUENCY_ATTR_MAX_TX_POWER value: {payload:?}"
                 ))?)
             }
             NL80211_FREQUENCY_ATTR_DFS_STATE => Self::DfsState(
                 parse_u32(payload)
                     .context(format!(
-                    "Invalid NL80211_FREQUENCY_ATTR_MAX_TX_POWER value: {:?}",
-                    payload
+                    "Invalid NL80211_FREQUENCY_ATTR_MAX_TX_POWER value: {payload:?}"
                 ))?
                     .into(),
             ),
 
             NL80211_FREQUENCY_ATTR_DFS_TIME => {
                 Self::DfsTime(parse_u32(payload).context(format!(
-                    "Invalid NL80211_FREQUENCY_ATTR_DFS_TIME value: {:?}",
-                    payload
+                    "Invalid NL80211_FREQUENCY_ATTR_DFS_TIME value: {payload:?}"
                 ))?)
             }
             NL80211_FREQUENCY_ATTR_NO_HT40_MINUS => Self::NoHt40Minus,
@@ -1019,8 +1008,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
             NL80211_FREQUENCY_ATTR_NO_160MHZ => Self::No160Mhz,
             NL80211_FREQUENCY_ATTR_DFS_CAC_TIME => {
                 Self::DfsCacTime(parse_u32(payload).context(format!(
-                    "Invalid NL80211_FREQUENCY_ATTR_DFS_CAC_TIME value: {:?}",
-                    payload
+                    "Invalid NL80211_FREQUENCY_ATTR_DFS_CAC_TIME value: {payload:?}"
                 ))?)
             }
             NL80211_FREQUENCY_ATTR_INDOOR_ONLY => Self::IndoorOnly,
@@ -1029,8 +1017,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
             NL80211_FREQUENCY_ATTR_NO_10MHZ => Self::No10Mhz,
             NL80211_FREQUENCY_ATTR_WMM => {
                 let err_msg = format!(
-                    "Invalid NL80211_FREQUENCY_ATTR_WMM value {:?}",
-                    payload
+                    "Invalid NL80211_FREQUENCY_ATTR_WMM value {payload:?}"
                 );
                 let mut nlas = Vec::new();
                 for (index, nla) in NlasIterator::new(payload).enumerate() {
@@ -1049,8 +1036,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
             NL80211_FREQUENCY_ATTR_NO_HE => Self::NoHe,
             NL80211_FREQUENCY_ATTR_OFFSET => {
                 Self::Offset(parse_u32(payload).context(format!(
-                    "Invalid NL80211_FREQUENCY_ATTR_OFFSET value {:?}",
-                    payload
+                    "Invalid NL80211_FREQUENCY_ATTR_OFFSET value {payload:?}"
                 ))?)
             }
             NL80211_FREQUENCY_ATTR_1MHZ => Self::Allow1Mhz,
@@ -1138,7 +1124,7 @@ where
     ) -> Result<Self, DecodeError> {
         let payload = buf.value();
         let err_msg =
-            format!("Invalid NL80211_BAND_ATTR_RATES value {:?}", payload);
+            format!("Invalid NL80211_BAND_ATTR_RATES value {payload:?}");
         let mut attributes = Vec::new();
         for nla in NlasIterator::new(payload) {
             let nla = &nla.context(err_msg.clone())?;
@@ -1194,8 +1180,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nl80211Rate {
         Ok(match buf.kind() {
             NL80211_BITRATE_ATTR_RATE => {
                 Self::Rate(parse_u32(payload).context(format!(
-                    "Invalid NL80211_BITRATE_ATTR_RATE value {:?}",
-                    payload
+                    "Invalid NL80211_BITRATE_ATTR_RATE value {payload:?}"
                 ))?)
             }
             NL80211_BITRATE_ATTR_2GHZ_SHORTPREAMBLE => {
@@ -1308,7 +1293,7 @@ where
     ) -> Result<Self, DecodeError> {
         let payload = buf.value();
         let err_msg =
-            format!("Invalid NL80211_FREQUENCY_ATTR_WMM value {:?}", payload);
+            format!("Invalid NL80211_FREQUENCY_ATTR_WMM value {payload:?}");
         let mut attributes = Vec::new();
         for nla in NlasIterator::new(payload) {
             let nla = &nla.context(err_msg.clone())?;
@@ -1375,16 +1360,16 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
         let payload = buf.value();
         Ok(match buf.kind() {
             NL80211_WMMR_CW_MIN => Self::CwMin(parse_u16(payload).context(
-                format!("Invalid NL80211_WMMR_CW_MIN value {:?}", payload),
+                format!("Invalid NL80211_WMMR_CW_MIN value {payload:?}"),
             )?),
             NL80211_WMMR_CW_MAX => Self::CwMax(parse_u16(payload).context(
-                format!("Invalid NL80211_WMMR_CW_MAX value {:?}", payload),
+                format!("Invalid NL80211_WMMR_CW_MAX value {payload:?}"),
             )?),
             NL80211_WMMR_AIFSN => Self::Aifsn(parse_u8(payload).context(
-                format!("Invalid NL80211_WMMR_AIFSN value {:?}", payload),
+                format!("Invalid NL80211_WMMR_AIFSN value {payload:?}"),
             )?),
             NL80211_WMMR_TXOP => Self::Txop(parse_u16(payload).context(
-                format!("Invalid NL80211_WMMR_CW_MAX value {:?}", payload),
+                format!("Invalid NL80211_WMMR_CW_MAX value {payload:?}"),
             )?),
             _ => Self::Other(
                 DefaultNla::parse(buf).context("invalid NLA (unknown kind)")?,

--- a/src/wiphy/wowlan.rs
+++ b/src/wiphy/wowlan.rs
@@ -179,8 +179,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                 let mut nlas = Vec::new();
                 for nla in NlasIterator::new(payload) {
                     let err_msg = format!(
-                        "Invalid NL80211_WOWLAN_TRIG_TCP_CONNECTION value {:?}",
-                        nla
+                        "Invalid NL80211_WOWLAN_TRIG_TCP_CONNECTION value {nla:?}"
                     );
                     let nla = &nla.context(err_msg.clone())?;
                     nlas.push(Nl80211WowlanTcpTrigerSupport::parse(nla)?);


### PR DESCRIPTION
This implements first attribute (`Nl80211InterfaceType`), which can be changed via the `set` method. 

This PR adds the `Nl80211Interface` builder type, which could support changing other attributes of the interface in the future as well. 