### PR TITLE
example: Fix compiling failure on missing `.enable_io`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,4 +43,4 @@ env_logger = "0.9.0"
 
 [dev-dependencies.tokio]
 version = "1.11.0"
-features = ["macros", "rt", "rt-multi-thread", "time"]
+features = ["macros", "rt", "rt-multi-thread", "time", "net"]

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -63,7 +63,7 @@ impl From<Nl80211ChannelWidth> for u32 {
             Nl80211ChannelWidth::Mhz(16) => NL80211_CHAN_WIDTH_16,
             Nl80211ChannelWidth::Mhz(320) => NL80211_CHAN_WIDTH_320,
             Nl80211ChannelWidth::Mhz(_) => {
-                log::warn!("Invalid Nl80211ChannelWidth {:?}", v);
+                log::warn!("Invalid Nl80211ChannelWidth {v:?}");
                 u32::MAX
             }
             Nl80211ChannelWidth::Other(d) => d,

--- a/src/mlo.rs
+++ b/src/mlo.rs
@@ -110,8 +110,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                 Nl80211MloLinkNla::Mac(s) => ret.mac = s,
                 Nl80211MloLinkNla::Other(attr) => {
                     log::warn!(
-                        "Got unsupported NL80211_ATTR_MLO_LINKS value {:?}",
-                        attr
+                        "Got unsupported NL80211_ATTR_MLO_LINKS value {attr:?}"
                     )
                 }
             }

--- a/src/station/rate_info.rs
+++ b/src/station/rate_info.rs
@@ -123,7 +123,7 @@ impl Nla for Nl80211RateInfo {
             Self::MhzWidth(160) => NL80211_RATE_INFO_160_MHZ_WIDTH,
             Self::MhzWidth(320) => NL80211_RATE_INFO_320_MHZ_WIDTH,
             Self::MhzWidth(freq) => {
-                log::warn!("Invalid Nl80211RateInfo::MhzWidth {:?}", freq);
+                log::warn!("Invalid Nl80211RateInfo::MhzWidth {freq:?}");
                 u16::MAX
             }
             Self::MhzWidth80Plus80 => NL80211_RATE_INFO_80P80_MHZ_WIDTH,
@@ -384,7 +384,7 @@ impl From<Nl80211HeRuAllocation> for u8 {
                 NL80211_RATE_INFO_HE_RU_ALLOC_996
             }
             Nl80211HeRuAllocation::Tone(_) => {
-                log::warn!("Invalid Nl80211HeRuAllocation {:?}", v);
+                log::warn!("Invalid Nl80211HeRuAllocation {v:?}");
                 u8::MAX
             }
             Nl80211HeRuAllocation::Tone2x996 => {
@@ -516,7 +516,7 @@ impl From<Nl80211EhtRuAllocation> for u8 {
                 NL80211_RATE_INFO_EHT_RU_ALLOC_996
             }
             Nl80211EhtRuAllocation::Tone(_) => {
-                log::warn!("Invalid Nl80211EhtRuAllocation {:?}", v);
+                log::warn!("Invalid Nl80211EhtRuAllocation {v:?}");
                 u8::MAX
             }
             Nl80211EhtRuAllocation::Tone52Plus26 => {


### PR DESCRIPTION
The `net` feature of tokio is required to run example.