### PR TITLE
Fix emit inconsitencies and add tests

### DIFF
--- a/src/element.rs
+++ b/src/element.rs
@@ -9,6 +9,9 @@ use crate::{
     Nl80211ElementHeCap, Nl80211ElementHtCap, Nl80211ElementVhtCap,
 };
 
+#[cfg(test)]
+mod test;
+
 /// [Nl80211Elements] Vec
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Nl80211Elements(pub Vec<Nl80211Element>);
@@ -214,9 +217,10 @@ const BSS_MEMBERSHIP_SELECTOR_HT_PHY: u8 = 127;
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[non_exhaustive]
 pub enum Nl80211RateAndSelector {
-    /// BSS basic rate set in 500 kb/s.
+    /// BSS basic rate in units of 500 kb/s, if necessary rounded up to the
+    /// next 500 kbs.
     BssBasicRateSet(u8),
-    /// Rate in 500kb/s.
+    /// Rate in units of 500 kb/s, if necessary rounded up to the next 500 kbs.
     Rate(u8),
     SelectorHt,
     SelectorVht,
@@ -237,9 +241,9 @@ pub enum Nl80211RateAndSelector {
 
 impl From<u8> for Nl80211RateAndSelector {
     fn from(d: u8) -> Self {
-        let msb: bool = (d & 1 << 7) > 0;
-        let value = d & 0b01111111;
-
+        const MSB_MASK: u8 = 0b1000_0000;
+        let msb: bool = (d & MSB_MASK) == MSB_MASK;
+        let value = d & !MSB_MASK;
         if msb {
             match value {
                 BSS_MEMBERSHIP_SELECTOR_SAE_HASH => Self::SelectorSaeHash,
@@ -257,22 +261,23 @@ impl From<u8> for Nl80211RateAndSelector {
 
 impl From<Nl80211RateAndSelector> for u8 {
     fn from(v: Nl80211RateAndSelector) -> u8 {
+        const MSB: u8 = 0b1000_0000;
         match v {
-            Nl80211RateAndSelector::BssBasicRateSet(r) => (r) | 1 << 7,
+            Nl80211RateAndSelector::BssBasicRateSet(r) => r & !MSB | MSB,
             Nl80211RateAndSelector::SelectorHt => {
-                BSS_MEMBERSHIP_SELECTOR_HT_PHY | 1 << 7
+                BSS_MEMBERSHIP_SELECTOR_HT_PHY | MSB
             }
             Nl80211RateAndSelector::SelectorVht => {
-                BSS_MEMBERSHIP_SELECTOR_VHT_PHY | 1 << 7
+                BSS_MEMBERSHIP_SELECTOR_VHT_PHY | MSB
             }
             Nl80211RateAndSelector::SelectorGlk => {
-                BSS_MEMBERSHIP_SELECTOR_GLK | 1 << 7
+                BSS_MEMBERSHIP_SELECTOR_GLK | MSB
             }
             Nl80211RateAndSelector::SelectorEpd => {
-                BSS_MEMBERSHIP_SELECTOR_EPD | 1 << 7
+                BSS_MEMBERSHIP_SELECTOR_EPD | MSB
             }
             Nl80211RateAndSelector::SelectorSaeHash => {
-                BSS_MEMBERSHIP_SELECTOR_SAE_HASH | 1 << 7
+                BSS_MEMBERSHIP_SELECTOR_SAE_HASH | MSB
             }
             Nl80211RateAndSelector::Rate(r) => r,
         }
@@ -334,7 +339,7 @@ impl Emitable for Nl80211ElementCountry {
             buffer[0] = self.country.as_bytes()[0];
             buffer[1] = self.country.as_bytes()[1];
         }
-        buffer[3] = self.environment.into();
+        buffer[2] = self.environment.into();
         for (i, triplet) in self.triplets.as_slice().iter().enumerate() {
             triplet.emit(&mut buffer[(i + 1) * 3..(i + 2) * 3]);
         }

--- a/src/element/test.rs
+++ b/src/element/test.rs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+
+use netlink_packet_core::{Emitable, Parseable};
+
+use super::{
+    Nl80211AkmSuite, Nl80211CipherSuite, Nl80211Element, Nl80211ElementCountry,
+    Nl80211ElementCountryEnvironment, Nl80211ElementCountryTriplet,
+    Nl80211ElementRsn, Nl80211ElementSubBand, Nl80211RateAndSelector,
+};
+
+#[test]
+fn ssid() {
+    let val: Nl80211Element = Nl80211Element::Ssid("test-ssid".to_owned());
+    let mut buffer = vec![0; val.buffer_len() + 1];
+    val.emit(buffer.as_mut_slice());
+    assert_eq!(
+        <Nl80211Element>::parse(&buffer[0..val.buffer_len()]).unwrap(),
+        val,
+    );
+}
+
+#[test]
+fn rates_and_selectors() {
+    let val: Nl80211Element = Nl80211Element::SupportedRatesAndSelectors(vec![
+        Nl80211RateAndSelector::BssBasicRateSet(1),
+        Nl80211RateAndSelector::Rate(1),
+        Nl80211RateAndSelector::SelectorHt,
+        Nl80211RateAndSelector::SelectorVht,
+        Nl80211RateAndSelector::SelectorGlk,
+    ]);
+    let mut buffer = vec![0; val.buffer_len() + 1];
+    val.emit(buffer.as_mut_slice());
+    assert_eq!(
+        <Nl80211Element>::parse(&buffer[0..val.buffer_len()]).unwrap(),
+        val,
+    );
+}
+
+#[test]
+fn channel() {
+    let val: Nl80211Element = Nl80211Element::Channel(7);
+    let mut buffer = vec![0; val.buffer_len() + 1];
+    val.emit(buffer.as_mut_slice());
+    assert_eq!(
+        <Nl80211Element>::parse(&buffer[0..val.buffer_len()]).unwrap(),
+        val,
+    );
+}
+
+#[test]
+fn country() {
+    let val: Nl80211Element = Nl80211Element::Country(Nl80211ElementCountry {
+        country: "DE".to_owned(),
+        environment: Nl80211ElementCountryEnvironment::IndoorAndOutdoor,
+        triplets: vec![Nl80211ElementCountryTriplet::Subband(
+            Nl80211ElementSubBand {
+                channel_start: 1,
+                channel_count: 13,
+                max_power_level: 20,
+            },
+        )],
+    });
+    let mut buffer = vec![0; val.buffer_len() + 1];
+    val.emit(buffer.as_mut_slice());
+    assert_eq!(
+        <Nl80211Element>::parse(&buffer[0..val.buffer_len()]).unwrap(),
+        val,
+    );
+}
+
+#[test]
+fn rsn() {
+    let val: Nl80211Element = Nl80211Element::Rsn(Nl80211ElementRsn {
+        version: 1,
+        group_cipher: Some(Nl80211CipherSuite::Ccmp128),
+        pairwise_ciphers: vec![Nl80211CipherSuite::Ccmp128],
+        akm_suits: vec![Nl80211AkmSuite::Psk],
+        rsn_capbilities: None,
+        pmkids: Vec::new(),
+        group_mgmt_cipher: None,
+    });
+    let mut buffer = vec![0; val.buffer_len() + 1];
+    val.emit(buffer.as_mut_slice());
+    assert_eq!(
+        <Nl80211Element>::parse(&buffer[0..val.buffer_len()]).unwrap(),
+        val,
+    );
+}

--- a/src/wifi4.rs
+++ b/src/wifi4.rs
@@ -9,6 +9,9 @@ use netlink_packet_core::{
 
 use crate::bytes::{get_bit, get_bits_as_u8, write_u16_le};
 
+#[cfg(test)]
+mod test;
+
 const NL80211_CHAN_NO_HT: u32 = 0;
 const NL80211_CHAN_HT20: u32 = 1;
 const NL80211_CHAN_HT40MINUS: u32 = 2;
@@ -123,7 +126,7 @@ impl Emitable for Nl80211HtCaps {
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        buffer.copy_from_slice(&self.bits().to_ne_bytes())
+        buffer[0..self.buffer_len()].copy_from_slice(&self.bits().to_ne_bytes())
     }
 }
 
@@ -469,9 +472,9 @@ impl From<Nl80211HtExtendedCap> for [u8; 2] {
     fn from(v: Nl80211HtExtendedCap) -> [u8; 2] {
         [
             v.pco as u8 | (v.pco_trans_time << 1) | (v.mcs_feedback & 0b1) << 7,
-            ((v.mcs_feedback & 0b10) >> 1)
-                | ((v.support_ht_control as u8) << 1)
-                | ((v.rd_responder as u8) << 2),
+            (v.mcs_feedback & 0b11)
+                | ((v.support_ht_control as u8) << 2)
+                | ((v.rd_responder as u8) << 3),
         ]
     }
 }
@@ -626,7 +629,7 @@ impl Emitable for Nl80211HtTransmitBeamformingCaps {
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        buffer.copy_from_slice(&self.bits().to_ne_bytes())
+        buffer[0..self.buffer_len()].copy_from_slice(&self.bits().to_ne_bytes())
     }
 }
 
@@ -674,6 +677,6 @@ impl Emitable for Nl80211HtAselCaps {
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        buffer.copy_from_slice(&self.bits().to_ne_bytes())
+        buffer[0..self.buffer_len()].copy_from_slice(&self.bits().to_ne_bytes())
     }
 }

--- a/src/wifi4/test.rs
+++ b/src/wifi4/test.rs
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: MIT
+
+use super::{
+    Emitable, Nl80211ElementHtCap, Nl80211HtAMpduPara, Nl80211HtAselCaps,
+    Nl80211HtCaps, Nl80211HtExtendedCap, Nl80211HtMcsInfo,
+    Nl80211HtTransmitBeamformingCaps, Nl80211HtTxParameter,
+    Nl80211HtWiphyChannelType, Parseable, IEEE80211_HT_MCS_MASK_LEN,
+    NL80211_CHAN_HT40PLUS,
+};
+
+#[test]
+fn caps() {
+    let val: Nl80211HtCaps = Nl80211HtCaps::all();
+    let mut buffer = vec![0; val.buffer_len() + 1];
+    val.emit(buffer.as_mut_slice());
+    assert_eq!(
+        <Nl80211HtCaps>::parse(&buffer[0..val.buffer_len()]).unwrap(),
+        val,
+    );
+}
+
+#[test]
+fn asel_caps() {
+    let val: Nl80211HtAselCaps = Nl80211HtAselCaps::all();
+    let mut buffer = vec![0; val.buffer_len() + 1];
+    val.emit(buffer.as_mut_slice());
+    assert_eq!(
+        <Nl80211HtAselCaps>::parse(&buffer[0..val.buffer_len()]).unwrap(),
+        val,
+    );
+}
+
+#[test]
+fn transmit_beamforming_cap() {
+    let val: Nl80211HtTransmitBeamformingCaps =
+        Nl80211HtTransmitBeamformingCaps::all();
+    let mut buffer = vec![0; val.buffer_len() + 1];
+    val.emit(buffer.as_mut_slice());
+    assert_eq!(
+        <Nl80211HtTransmitBeamformingCaps>::parse(&buffer[0..val.buffer_len()])
+            .unwrap(),
+        val,
+    );
+}
+
+#[test]
+fn tx_params() {
+    let val: Nl80211HtTxParameter = Nl80211HtTxParameter {
+        mcs_set_defined: false,
+        tx_rx_mcs_set_not_equal: false,
+        max_spatial_streams: 1,
+        unequal_modulation_supported: false,
+    };
+    let into: u8 = val.into();
+    assert_eq!(<Nl80211HtTxParameter>::from(into), val,);
+}
+
+#[test]
+fn ht_wiphy_no_ht() {
+    let val: Nl80211HtWiphyChannelType = Nl80211HtWiphyChannelType::NoHt;
+    let into: u32 = val.into();
+    assert_eq!(<Nl80211HtWiphyChannelType>::from(into), val,);
+}
+
+#[test]
+fn ht_wiphy_ht_20() {
+    let val: Nl80211HtWiphyChannelType = Nl80211HtWiphyChannelType::Ht20;
+    let into: u32 = val.into();
+    assert_eq!(<Nl80211HtWiphyChannelType>::from(into), val,);
+}
+
+#[test]
+fn ht_wiphy_other() {
+    let val: Nl80211HtWiphyChannelType =
+        Nl80211HtWiphyChannelType::Other(NL80211_CHAN_HT40PLUS + 1);
+    let into: u32 = val.into();
+    assert_eq!(<Nl80211HtWiphyChannelType>::from(into), val,);
+}
+
+#[test]
+fn mcs_info() {
+    let val: Nl80211HtMcsInfo = Nl80211HtMcsInfo {
+        rx_mask: [0xA5; IEEE80211_HT_MCS_MASK_LEN],
+        rx_highest: u16::MAX,
+        tx_params: Nl80211HtTxParameter {
+            mcs_set_defined: false,
+            tx_rx_mcs_set_not_equal: false,
+            max_spatial_streams: 1,
+            unequal_modulation_supported: false,
+        },
+    };
+    let mut buffer = vec![0; val.buffer_len() + 1];
+    val.emit(buffer.as_mut_slice());
+    assert_eq!(
+        <Nl80211HtMcsInfo>::parse(&buffer[0..val.buffer_len()]).unwrap(),
+        val,
+    );
+}
+
+#[test]
+fn a_mpdu_para() {
+    let val: Nl80211HtAMpduPara = Nl80211HtAMpduPara {
+        max_len_exponent: u8::MAX & 0b11,
+        min_space: u8::MAX & 0b111,
+    };
+    let into: u8 = val.into();
+    assert_eq!(<Nl80211HtAMpduPara>::from(into), val,);
+}
+
+#[test]
+fn extend_cap() {
+    let val: Nl80211HtExtendedCap = Nl80211HtExtendedCap {
+        pco: true,
+        pco_trans_time: 1,
+        mcs_feedback: 1,
+        support_ht_control: true,
+        rd_responder: true,
+    };
+    let into: [u8; 2] = val.into();
+    assert_eq!(<Nl80211HtExtendedCap>::from(into), val,);
+}
+
+#[test]
+fn cap_mask() {
+    let val: Nl80211ElementHtCap = Nl80211ElementHtCap {
+        caps: Nl80211HtCaps::all(),
+        a_mpdu_para: Nl80211HtAMpduPara {
+            max_len_exponent: 3,
+            min_space: 7,
+        },
+        mcs_set: Nl80211HtMcsInfo {
+            rx_mask: [0xA5; IEEE80211_HT_MCS_MASK_LEN],
+            rx_highest: u16::MAX,
+            tx_params: Nl80211HtTxParameter {
+                mcs_set_defined: false,
+                tx_rx_mcs_set_not_equal: false,
+                max_spatial_streams: 1,
+                unequal_modulation_supported: false,
+            },
+        },
+        ht_ext_cap: Nl80211HtExtendedCap {
+            pco: true,
+            pco_trans_time: 2,
+            mcs_feedback: 2,
+            support_ht_control: true,
+            rd_responder: true,
+        },
+        transmit_beamforming_cap: Nl80211HtTransmitBeamformingCaps::all(),
+        asel_cap: Nl80211HtAselCaps::all(),
+    };
+    let mut buffer = vec![0; val.buffer_len() + 1];
+    val.emit(buffer.as_mut_slice());
+    assert_eq!(
+        <Nl80211ElementHtCap>::parse(&buffer[0..val.buffer_len()]).unwrap(),
+        val,
+    );
+}


### PR DESCRIPTION
While trying to convert the parsed payload of information elements into the binary format, I've noticed inconsistencies regarding some emit implementations. 

I've fixed some of them (which I needed) mostly based on the assumption, that the `Parsable` implementation is correct. 
On exception is the `Nl80211RateAndSelector` implementation, where the comments from this type and `Nl80211Element::SupportedRatesAndSelectors` where already inconsistent. 

Also I've added some roudtrip test, using macros to reduce the repetition. I thought about adding more tests, but I wanted to propose this as a starting point for now. 