### PR TITLE
Fix typos

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -48,7 +48,7 @@ use crate::{
     Nl80211InterfaceType, Nl80211InterfaceTypes, Nl80211MloLink,
     Nl80211ScanFlags, Nl80211SchedScanMatch, Nl80211SchedScanPlan,
     Nl80211StationInfo, Nl80211TransmitQueueStat, Nl80211VhtCapability,
-    Nl80211WowlanTrigersSupport,
+    Nl80211WowlanTriggersSupport,
 };
 
 const ETH_ALEN: usize = 6;
@@ -519,7 +519,7 @@ pub enum Nl80211Attr {
     /// in milliseconds
     MaxRemainOnChannelDuration(u32),
     OffchannelTxOk,
-    WowlanTrigersSupport(Vec<Nl80211WowlanTrigersSupport>),
+    WowlanTriggersSupport(Vec<Nl80211WowlanTriggersSupport>),
     SoftwareIftypes(Vec<Nl80211InterfaceType>),
     Features(Nl80211Features),
     ExtFeatures(Vec<Nl80211ExtFeature>),
@@ -644,7 +644,7 @@ impl Nla for Nl80211Attr {
                 Nl80211Commands::from(s).as_slice().buffer_len()
             }
             Self::MaxRemainOnChannelDuration(_) => 4,
-            Self::WowlanTrigersSupport(s) => s.as_slice().buffer_len(),
+            Self::WowlanTriggersSupport(s) => s.as_slice().buffer_len(),
             Self::SoftwareIftypes(s) => {
                 Nl80211InterfaceTypes::from(s).as_slice().buffer_len()
             }
@@ -743,7 +743,7 @@ impl Nla for Nl80211Attr {
                 NL80211_ATTR_MAX_REMAIN_ON_CHANNEL_DURATION
             }
             Self::OffchannelTxOk => NL80211_ATTR_OFFCHANNEL_TX_OK,
-            Self::WowlanTrigersSupport(_) => {
+            Self::WowlanTriggersSupport(_) => {
                 NL80211_ATTR_WOWLAN_TRIGGERS_SUPPORTED
             }
             Self::SoftwareIftypes(_) => NL80211_ATTR_SOFTWARE_IFTYPES,
@@ -864,7 +864,7 @@ impl Nla for Nl80211Attr {
                 Nl80211Commands::from(s).as_slice().emit(buffer)
             }
             Self::MaxRemainOnChannelDuration(d) => write_u32(buffer, *d),
-            Self::WowlanTrigersSupport(s) => s.as_slice().emit(buffer),
+            Self::WowlanTriggersSupport(s) => s.as_slice().emit(buffer),
             Self::SoftwareIftypes(s) => {
                 Nl80211InterfaceTypes::from(s).as_slice().emit(buffer)
             }
@@ -1250,9 +1250,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nl80211Attr {
                         value {nla:?}"
                     );
                     let nla = &nla.context(err_msg.clone())?;
-                    nlas.push(Nl80211WowlanTrigersSupport::parse(nla)?);
+                    nlas.push(Nl80211WowlanTriggersSupport::parse(nla)?);
                 }
-                Self::WowlanTrigersSupport(nlas)
+                Self::WowlanTriggersSupport(nlas)
             }
             NL80211_ATTR_OFFCHANNEL_TX_OK => Self::OffchannelTxOk,
             NL80211_ATTR_SOFTWARE_IFTYPES => Self::SoftwareIftypes(

--- a/src/element.rs
+++ b/src/element.rs
@@ -429,7 +429,7 @@ impl From<[u8; 3]> for Nl80211ElementSubBand {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Nl80211ElementOperating {
-    pub extention_id: u8,
+    pub extension_id: u8,
     pub operating_class: u8,
     /// The `aAirPropagationTime` is `coverage_class` * 3 in μs for range
     /// between 0 - 31. Bigger than 31 is reserved.
@@ -442,7 +442,7 @@ impl Emitable for Nl80211ElementOperating {
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        buffer[0] = self.extention_id;
+        buffer[0] = self.extension_id;
         buffer[1] = self.operating_class;
         buffer[2] = self.coverage_class;
     }
@@ -451,7 +451,7 @@ impl Emitable for Nl80211ElementOperating {
 impl From<[u8; 3]> for Nl80211ElementOperating {
     fn from(buf: [u8; 3]) -> Self {
         Self {
-            extention_id: buf[0],
+            extension_id: buf[0],
             operating_class: buf[1],
             coverage_class: buf[2],
         }

--- a/src/iface/set.rs
+++ b/src/iface/set.rs
@@ -38,7 +38,7 @@ impl Nl80211InterfaceSetRequest {
             attributes: dbg!(attributes),
         };
         // TODO: is the in iw dev set
-        // I don't understand the correct seting of flags yet. In case of set
+        // I don't understand the correct setting of flags yet. In case of set
         // `iw` does not set any flag, but here NLM_F_REQUEST is always
         // set. Curentliy infreadead.org libnl documentation website is
         // down. These are the same flags as in scan.rs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ pub use self::wiphy::{
     Nl80211Channel, Nl80211ChannelSwitchRequest, Nl80211CipherSuit,
     Nl80211Frequency, Nl80211FrequencyInfo, Nl80211IfMode,
     Nl80211WiphyGetRequest, Nl80211WiphyHandle, Nl80211WowlanTcpTrigerSupport,
-    Nl80211WowlanTrigerPatternSupport, Nl80211WowlanTrigersSupport,
+    Nl80211WowlanTrigerPatternSupport, Nl80211WowlanTriggersSupport,
 };
 
 pub(crate) use self::element::Nl80211Elements;

--- a/src/scan/handle.rs
+++ b/src/scan/handle.rs
@@ -109,7 +109,7 @@ impl Nl80211AttrsBuilder<Nl80211Scan> {
     }
 
     /// Scan frequencies in MHz.
-    pub fn scan_frequncies(self, freqs: Vec<u32>) -> Self {
+    pub fn scan_frequencies(self, freqs: Vec<u32>) -> Self {
         self.replace(Nl80211Attr::ScanFrequencies(freqs))
     }
 

--- a/src/station/station_info.rs
+++ b/src/station/station_info.rs
@@ -116,9 +116,9 @@ pub enum Nl80211StationInfo {
     StationFlags(Nl80211StationFlagUpdate),
     /// Timing offset with respect to this station
     TimingOffset(i64),
-    /// Local mesh staion link-specific power mode
+    /// Local mesh station link-specific power mode
     LocalPowerMode(Nl80211MeshPowerMode),
-    /// Peer mesh staion link-specific power mode
+    /// Peer mesh station link-specific power mode
     PeerPowerMode(Nl80211MeshPowerMode),
     /// Neighbor mesh station power save mode towards non-peer station
     NonPeerPowerMode(Nl80211MeshPowerMode),

--- a/src/wifi4.rs
+++ b/src/wifi4.rs
@@ -517,16 +517,16 @@ bitflags::bitflags! {
         const ExplicitTransmitCsiFeedbackImmediate = 1 << 12;
         /// Indicates this receiver can return delayed noncompressed
         /// beamforming feedback matrix explicit feedback
-        const ExplicitNoncompressedFeebackDelay = 1 << 13;
+        const ExplicitNoncompressedFeedbackDelay = 1 << 13;
         /// Indicates this receiver can return immediate noncompressed
         /// beamforming feedback matrix explicit feedback
-        const ExplicitNoncompressedFeebackImmediate = 1 << 14;
+        const ExplicitNoncompressedFeedbackImmediate = 1 << 14;
         /// Indicates this receiver can return delayed compressed
         /// beamforming feedback matrix explicit feedback
-        const ExplicitCompressedFeebackDelay = 1 << 15;
+        const ExplicitCompressedFeedbackDelay = 1 << 15;
         /// Indicates this receiver can return immediate compressed
         /// beamforming feedback matrix explicit feedback
-        const ExplicitCompressedFeebackImmediate = 1 << 16;
+        const ExplicitCompressedFeedbackImmediate = 1 << 16;
         /// Support 2 minimal groups used for explicit feedback report
         /// Unset means 1 minimal grouping.
         const MinimalGrouping2 = 1 << 17;

--- a/src/wifi6.rs
+++ b/src/wifi6.rs
@@ -69,7 +69,7 @@ impl Nl80211HeMacCapInfo {
     pub fn roadcast_twt_support(&self) -> bool {
         get_bit(&self.0, 20)
     }
-    pub fn upport_32_bit_ba_bitmap(&self) -> bool {
+    pub fn support_32_bit_ba_bitmap(&self) -> bool {
         get_bit(&self.0, 21)
     }
     pub fn u_cascading_support(&self) -> bool {
@@ -130,7 +130,7 @@ impl Nl80211HeMacCapInfo {
     pub fn m_control_ul_mu_data_disable_rx_support(&self) -> bool {
         get_bit(&self.0, 44)
     }
-    pub fn e_dyanmic_sm_power_save(&self) -> bool {
+    pub fn e_dynamic_sm_power_save(&self) -> bool {
         get_bit(&self.0, 45)
     }
     pub fn unctured_sounding_support(&self) -> bool {

--- a/src/wiphy/mod.rs
+++ b/src/wiphy/mod.rs
@@ -20,7 +20,7 @@ pub use self::ifmode::Nl80211IfMode;
 pub use self::set::Nl80211ChannelSwitchRequest;
 pub use self::wowlan::{
     Nl80211WowlanTcpTrigerSupport, Nl80211WowlanTrigerPatternSupport,
-    Nl80211WowlanTrigersSupport,
+    Nl80211WowlanTriggersSupport,
 };
 
 pub(crate) use self::command::Nl80211Commands;

--- a/src/wiphy/wowlan.rs
+++ b/src/wiphy/wowlan.rs
@@ -61,7 +61,7 @@ const NL80211_WOWLAN_TRIG_NET_DETECT: u16 = 18;
 
 /// Supported WoWLAN trigger
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub enum Nl80211WowlanTrigersSupport {
+pub enum Nl80211WowlanTriggersSupport {
     /// Wake up on any activity, do not really put the chip into a special
     /// state -- works best with chips that have support for low-power
     /// operation already.
@@ -99,7 +99,7 @@ pub enum Nl80211WowlanTrigersSupport {
     Other(DefaultNla),
 }
 
-impl Nla for Nl80211WowlanTrigersSupport {
+impl Nla for Nl80211WowlanTriggersSupport {
     fn value_len(&self) -> usize {
         match self {
             Self::Any
@@ -153,7 +153,7 @@ impl Nla for Nl80211WowlanTrigersSupport {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
-    for Nl80211WowlanTrigersSupport
+    for Nl80211WowlanTriggersSupport
 {
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = buf.value();

--- a/tools/make_release.sh
+++ b/tools/make_release.sh
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 MAIN_BRANCH_NAME="main"
-UPSTERAM_GIT="https://github.com/rust-netlink/wl-nl80211.git"
+UPSTREAM_GIT="https://github.com/rust-netlink/wl-nl80211.git"
 TMP_CHANGELOG_FILE=$(mktemp)
 EDITOR="${EDITOR:-vim}"
 
@@ -19,7 +19,7 @@ then
 fi
 
 
-CHANGLOG_FORMAT="
+CHANGELOG_FORMAT="
 ### Breaking changes\n\
  - N/A\n\
 \n\
@@ -50,7 +50,7 @@ NEXT_VERSION="${CUR_MAJOR_VERSION}.$((CUR_MINOR_VERSION + 1)).0";
 
 git branch new_release || true
 git checkout new_release
-git fetch upstream || (git remote add upstream $UPSTERAM_GIT; \
+git fetch upstream || (git remote add upstream $UPSTREAM_GIT; \
     git fetch upstream)
 git reset --hard upstream/$MAIN_BRANCH_NAME
 
@@ -60,7 +60,7 @@ cargo publish --dry-run --allow-dirty
 
 echo "# Changelog" > $TMP_CHANGELOG_FILE
 echo "## [$NEXT_VERSION] - $(date +%F)" >> $TMP_CHANGELOG_FILE
-echo -e $CHANGLOG_FORMAT >> $TMP_CHANGELOG_FILE
+echo -e $CHANGELOG_FORMAT >> $TMP_CHANGELOG_FILE
 git log --oneline --format=" - %s. (%h)" \
     v${CUR_VERSION}..upstream/$MAIN_BRANCH_NAME -- | \
     grep -v -E '^ - test:' | \


### PR DESCRIPTION
This is a breaking change, as this changes typos in type names. 

`Emitable` -> `Emittable` can't be fixed, as the trait definition is outside of this crate. 

The breaking changes can be avoided by type aliases or deprecation warnings. 

