### PR TITLE
Add a way to specify the interface on a get requests

### DIFF
--- a/examples/dump_nl80211_iface.rs
+++ b/examples/dump_nl80211_iface.rs
@@ -14,7 +14,8 @@ async fn get_interfaces() {
     let (connection, handle, _) = wl_nl80211::new_connection().unwrap();
     tokio::spawn(connection);
 
-    let mut interface_handle = handle.interface().get().execute().await;
+    let mut interface_handle =
+        handle.interface().get(Vec::new()).execute().await;
 
     let mut msgs = Vec::new();
     while let Some(msg) = interface_handle.try_next().await.unwrap() {

--- a/src/iface/get.rs
+++ b/src/iface/get.rs
@@ -5,30 +5,41 @@ use netlink_packet_core::{NLM_F_DUMP, NLM_F_REQUEST};
 use netlink_packet_generic::GenlMessage;
 
 use crate::{
-    nl80211_execute, Nl80211Command, Nl80211Error, Nl80211Handle,
+    nl80211_execute, Nl80211Attr, Nl80211Command, Nl80211Error, Nl80211Handle,
     Nl80211Message,
 };
 
 pub struct Nl80211InterfaceGetRequest {
     handle: Nl80211Handle,
+    attributes: Vec<Nl80211Attr>,
 }
 
 impl Nl80211InterfaceGetRequest {
-    pub(crate) fn new(handle: Nl80211Handle) -> Self {
-        Nl80211InterfaceGetRequest { handle }
+    pub(crate) fn new(
+        handle: Nl80211Handle,
+        attributes: Vec<Nl80211Attr>,
+    ) -> Self {
+        Nl80211InterfaceGetRequest { handle, attributes }
     }
 
     pub async fn execute(
         self,
     ) -> impl TryStream<Ok = GenlMessage<Nl80211Message>, Error = Nl80211Error>
     {
-        let Nl80211InterfaceGetRequest { mut handle } = self;
+        let Nl80211InterfaceGetRequest {
+            mut handle,
+            attributes,
+        } = self;
+
+        let mut flags = NLM_F_REQUEST;
+        if attributes.is_empty() {
+            flags |= NLM_F_DUMP;
+        }
 
         let nl80211_msg = Nl80211Message {
             cmd: Nl80211Command::GetInterface,
-            attributes: vec![],
+            attributes,
         };
-        let flags = NLM_F_REQUEST | NLM_F_DUMP;
 
         nl80211_execute(&mut handle, nl80211_msg, flags).await
     }

--- a/src/iface/handle.rs
+++ b/src/iface/handle.rs
@@ -33,8 +33,11 @@ impl Nl80211InterfaceHandle {
 
     /// Retrieve the wireless interfaces
     /// (equivalent to `iw dev`)
-    pub fn get(&mut self) -> Nl80211InterfaceGetRequest {
-        Nl80211InterfaceGetRequest::new(self.0.clone())
+    pub fn get(
+        &mut self,
+        attributes: Vec<Nl80211Attr>,
+    ) -> Nl80211InterfaceGetRequest {
+        Nl80211InterfaceGetRequest::new(self.0.clone(), attributes)
     }
 
     /// Set wireless interfaces attributes


### PR DESCRIPTION
This tries to keep it consistent with the `set` function also taking plain `attributes`. 

But it seems strange to set `Vec::new()` when all interface attributes are requested. Also distinguishing a `NLM_F_DUMP` request depending if the attributes are empty or not shows the weakness of the approach. 

This should act as a basis for discussion up to this point. 