### PR TITLE
New release 0.3.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,21 @@
 # Changelog
+## [0.3.0] - 2024-09-21
+### Breaking changes
+ - Replace `Nl80211Cmd` with `Nl80211Command`. (21896a4)
+
+### New features
+ - Support querying scan results. (3adb7b9)
+ - Support parsing HT(WIFI4) capability. (dc5cc16)
+ - Support scaning trigger and schedule. (c0dcf88)
+ - Support setting phy parameters. (25aef4e)
+ - Support changing interface type. (2d86585)
+ - Support specifying the interface on a get reques. (97bf087)
+ - Support dumpping survey. (cd9907f)
+
+### Bug fixes
+ - Fix Nl80211Element parser to allow zero-length elements. (7d4f45a)
+ - Use latest rust-netlink crates. (1fc0a2e)
+
 ## [0.2.0] - 2024-09-21
 ### Breaking changes
  - Changed `Nl80211Attr::WiPhyFreq` to `Nl80211Attr::WiphyFreq`. (2a4dbe1)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # The crate name `nl80211` is occupied
 name = "wl-nl80211"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "MIT"
 edition = "2021"


### PR DESCRIPTION
=== Breaking changes
 - Replace `Nl80211Cmd` with `Nl80211Command`. (21896a4)

=== New features
 - Support querying scan results. (3adb7b9)
 - Support parsing HT(WIFI4) capability. (dc5cc16)
 - Support scaning trigger and schedule. (c0dcf88)
 - Support setting phy parameters. (25aef4e)
 - Support changing interface type. (2d86585)
 - Support specifying the interface on a get reques. (97bf087)
 - Support dumpping survey. (cd9907f)

=== Bug fixes
 - Fix Nl80211Element parser to allow zero-length elements. (7d4f45a)
 - Use latest rust-netlink crates. (1fc0a2e)