### PR TITLE
New release 0.3.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,15 @@
 # Changelog
-## [0.3.0] - 2024-09-21
+## [0.3.1] - 2025-08-29
+### Breaking changes
+ - Set minimum supported rust version to 1.77. (d72680a)
+
+### New features
+ - N/A
+
+### Bug fixes
+ - Fix compiling error on rust 1.77. (d72680a)
+
+## [0.3.0] - 2025-08-27
 ### Breaking changes
  - Replace `Nl80211Cmd` with `Nl80211Command`. (21896a4)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # The crate name `nl80211` is occupied
 name = "wl-nl80211"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "MIT"
 edition = "2021"


### PR DESCRIPTION
=== Breaking changes
 - Set minimum supported rust version to 1.77. (d72680a)

=== New features
 - N/A

=== Bug fixes
 - Fix compiling error on rust 1.77. (d72680a)