### PR TITLE
New release 0.3.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,14 @@
 # Changelog
+## [0.3.2] - 2025-09-01
+### Breaking changes
+ - N/A
+
+### New features
+ - N/A
+
+### Bug fixes
+ - Leftover: Set minimum supported rust version to 1.77. (caed428)
+
 ## [0.3.1] - 2025-08-29
 ### Breaking changes
  - Set minimum supported rust version to 1.77. (d72680a)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # The crate name `nl80211` is occupied
 name = "wl-nl80211"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "MIT"
 edition = "2021"


### PR DESCRIPTION
=== Breaking changes
 - N/A

=== New features
 - N/A

=== Bug fixes
 - Leftover: Set minimum supported rust version to 1.77. (caed428)