### PR TITLE
Add attributes for connect/disconnect/auth/deauth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor/
 
 *.swp
 tags
+AGENTS.md

--- a/examples/interfaces.rs
+++ b/examples/interfaces.rs
@@ -63,7 +63,7 @@ fn main() -> anyhow::Result<()> {
                     _ => Err(anyhow!("Unknown interface type")),
                 })
                 .ok_or_else(|| anyhow!("No type specified"))
-                .flatten()?;
+                .and_then(|x| x)?;
             rt.block_on(new_interface(handle, phy_name, if_name, if_type))
         }
         Some("del") => {

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -39,18 +39,81 @@ use crate::{
     bytes::{write_u16, write_u32, write_u64},
     scan::{Nla80211ScanFreqNlas, Nla80211ScanSsidNlas},
     wiphy::Nl80211Commands,
-    Nl80211Band, Nl80211BandTypes, Nl80211BssInfo, Nl80211ChannelWidth,
-    Nl80211CipherSuit, Nl80211Command, Nl80211ExtFeature, Nl80211ExtFeatures,
-    Nl80211ExtendedCapability, Nl80211Features, Nl80211HtCapabilityMask,
-    Nl80211HtWiphyChannelType, Nl80211IfMode, Nl80211IfTypeExtCapa,
-    Nl80211IfTypeExtCapas, Nl80211IfaceComb, Nl80211IfaceFrameType,
-    Nl80211InterfaceType, Nl80211InterfaceTypes, Nl80211MloLink,
-    Nl80211ScanFlags, Nl80211SchedScanMatch, Nl80211SchedScanPlan,
-    Nl80211StationInfo, Nl80211SurveyInfo, Nl80211TransmitQueueStat,
-    Nl80211VhtCapability, Nl80211WowlanTriggersSupport,
+    Nl80211AkmSuite, Nl80211AuthType, Nl80211Band, Nl80211BandTypes,
+    Nl80211BssInfo, Nl80211ChannelWidth, Nl80211CipherSuit, Nl80211CipherSuite,
+    Nl80211Command, Nl80211ExtFeature, Nl80211ExtFeatures,
+    Nl80211ExtendedCapability, Nl80211ExternalAuthAction, Nl80211Features,
+    Nl80211HtCapabilityMask, Nl80211HtWiphyChannelType, Nl80211IfMode,
+    Nl80211IfTypeExtCapa, Nl80211IfTypeExtCapas, Nl80211IfaceComb,
+    Nl80211IfaceFrameType, Nl80211InterfaceType, Nl80211InterfaceTypes,
+    Nl80211MloLink, Nl80211ScanFlags, Nl80211SchedScanMatch,
+    Nl80211SchedScanPlan, Nl80211StationInfo, Nl80211SurveyInfo,
+    Nl80211TransmitQueueStat, Nl80211UseMfp, Nl80211VhtCapability,
+    Nl80211WowlanTriggersSupport, Nl80211WpaVersions,
 };
 
 const ETH_ALEN: usize = 6;
+
+fn parse_cipher_suites(
+    payload: &[u8],
+) -> Result<Vec<Nl80211CipherSuite>, DecodeError> {
+    if payload.len() % 4 != 0 {
+        return Err(format!(
+            "Invalid cipher suite list length {}, expecting multiple of 4",
+            payload.len()
+        )
+        .into());
+    }
+    Ok(payload
+        .chunks_exact(4)
+        .map(|c| {
+            // The kernel carries cipher-suite selectors as a *native-endian*
+            // u32 of the IEEE 802.11 OUI-based constant (e.g. `0x000fac04`
+            // for CCMP-128, see `WLAN_CIPHER_SUITE_CCMP`). `from_ne_bytes`
+            // recovers that constant regardless of host endianness: on
+            // little-endian the wire bytes `[0x04, 0xac, 0x0f, 0x00]` and on
+            // big-endian `[0x00, 0x0f, 0xac, 0x04]` both decode to
+            // `0x000fac04`.
+            //
+            // `.swap_bytes()` is then required because `Nl80211CipherSuite`
+            // (from element.rs) does NOT store the kernel constant: its u32 is
+            // the byte-reverse of it (`0x04ac0f00` = `IEEE_80211_OUI |
+            // (4 << 24)`), because that type derives its value from the
+            // information-element selector `[00, 0f, ac, 04]` read as
+            // little-endian. Swapping bridges the kernel constant
+            // (`0x000fac04`) and our internal representation (`0x04ac0f00`).
+            Nl80211CipherSuite::from(
+                u32::from_ne_bytes([c[0], c[1], c[2], c[3]]).swap_bytes(),
+            )
+        })
+        .collect())
+}
+
+fn parse_akm_suites(
+    payload: &[u8],
+) -> Result<Vec<Nl80211AkmSuite>, DecodeError> {
+    if payload.len() % 4 != 0 {
+        return Err(format!(
+            "Invalid AKM suite list length {}, expecting multiple of 4",
+            payload.len()
+        )
+        .into());
+    }
+    Ok(payload
+        .chunks_exact(4)
+        .map(|c| {
+            // AKM-suite selectors use the same wire encoding as cipher
+            // suites: a native-endian u32 of the kernel's OUI-based constant
+            // (e.g. `0x000fac08` for SAE). `.swap_bytes()` converts that
+            // constant to `Nl80211AkmSuite`'s byte-reversed internal
+            // representation (`0x08ac0f00` = `IEEE_80211_OUI | (8 << 24)`).
+            // See `parse_cipher_suites` for the full rationale.
+            Nl80211AkmSuite::from(
+                u32::from_ne_bytes([c[0], c[1], c[2], c[3]]).swap_bytes(),
+            )
+        })
+        .collect())
+}
 
 struct MacAddressNlas(Vec<MacAddressNla>);
 
@@ -125,7 +188,8 @@ const NL80211_ATTR_WIPHY_NAME: u16 = 2;
 const NL80211_ATTR_IFINDEX: u16 = 3;
 const NL80211_ATTR_IFNAME: u16 = 4;
 const NL80211_ATTR_IFTYPE: u16 = 5;
-const NL80211_ATTR_MAC: u16 = 6;
+// Also used by mlo.rs.
+pub(crate) const NL80211_ATTR_MAC: u16 = 6;
 // const NL80211_ATTR_KEY_DATA:u16 = 7;
 // const NL80211_ATTR_KEY_IDX:u16 = 8;
 // const NL80211_ATTR_KEY_CIPHER:u16 = 9;
@@ -161,7 +225,7 @@ const NL80211_ATTR_WIPHY_FREQ: u16 = 38;
 const NL80211_ATTR_WIPHY_CHANNEL_TYPE: u16 = 39;
 // const NL80211_ATTR_KEY_DEFAULT_MGMT:u16 = 40;
 // const NL80211_ATTR_MGMT_SUBTYPE:u16 = 41;
-// const NL80211_ATTR_IE:u16 = 42;
+const NL80211_ATTR_IE: u16 = 42;
 const NL80211_ATTR_MAX_NUM_SCAN_SSIDS: u16 = 43;
 const NL80211_ATTR_SCAN_FREQUENCIES: u16 = 44;
 const NL80211_ATTR_SCAN_SSIDS: u16 = 45;
@@ -170,10 +234,10 @@ const NL80211_ATTR_BSS: u16 = 47;
 // const NL80211_ATTR_REG_INITIATOR:u16 = 48;
 // const NL80211_ATTR_REG_TYPE:u16 = 49;
 const NL80211_ATTR_SUPPORTED_COMMANDS: u16 = 50;
-// const NL80211_ATTR_FRAME:u16 = 51;
+const NL80211_ATTR_FRAME: u16 = 51;
 const NL80211_ATTR_SSID: u16 = 52;
-// const NL80211_ATTR_AUTH_TYPE:u16 = 53;
-// const NL80211_ATTR_REASON_CODE:u16 = 54;
+const NL80211_ATTR_AUTH_TYPE: u16 = 53;
+const NL80211_ATTR_REASON_CODE: u16 = 54;
 // const NL80211_ATTR_KEY_TYPE:u16 = 55;
 const NL80211_ATTR_MAX_SCAN_IE_LEN: u16 = 56;
 const NL80211_ATTR_CIPHER_SUITES: u16 = 57;
@@ -185,17 +249,17 @@ const NL80211_ATTR_WIPHY_RETRY_LONG: u16 = 62;
 const NL80211_ATTR_WIPHY_FRAG_THRESHOLD: u16 = 63;
 const NL80211_ATTR_WIPHY_RTS_THRESHOLD: u16 = 64;
 // const NL80211_ATTR_TIMED_OUT:u16 = 65;
-// const NL80211_ATTR_USE_MFP:u16 = 66;
+const NL80211_ATTR_USE_MFP: u16 = 66;
 // const NL80211_ATTR_STA_FLAGS2:u16 = 67;
 // const NL80211_ATTR_CONTROL_PORT:u16 = 68;
 // const NL80211_ATTR_TESTDATA:u16 = 69;
-// const NL80211_ATTR_PRIVACY:u16 = 70;
+const NL80211_ATTR_PRIVACY: u16 = 70;
 // const NL80211_ATTR_DISCONNECTED_BY_AP:u16 = 71;
-// const NL80211_ATTR_STATUS_CODE:u16 = 72;
-// const NL80211_ATTR_CIPHER_SUITES_PAIRWISE:u16 = 73;
-// const NL80211_ATTR_CIPHER_SUITE_GROUP:u16 = 74;
-// const NL80211_ATTR_WPA_VERSIONS:u16 = 75;
-// const NL80211_ATTR_AKM_SUITES:u16 = 76;
+const NL80211_ATTR_STATUS_CODE: u16 = 72;
+const NL80211_ATTR_CIPHER_SUITES_PAIRWISE: u16 = 73;
+const NL80211_ATTR_CIPHER_SUITE_GROUP: u16 = 74;
+const NL80211_ATTR_WPA_VERSIONS: u16 = 75;
+const NL80211_ATTR_AKM_SUITES: u16 = 76;
 // const NL80211_ATTR_REQ_IE:u16 = 77;
 // const NL80211_ATTR_RESP_IE:u16 = 78;
 // const NL80211_ATTR_PREV_BSSID:u16 = 79;
@@ -207,11 +271,11 @@ const NL80211_ATTR_SURVEY_INFO: u16 = 84;
 // const NL80211_ATTR_PMKID:u16 = 85;
 const NL80211_ATTR_MAX_NUM_PMKIDS: u16 = 86;
 // const NL80211_ATTR_DURATION:u16 = 87;
-// const NL80211_ATTR_COOKIE:u16 = 88;
+const NL80211_ATTR_COOKIE: u16 = 88;
 const NL80211_ATTR_WIPHY_COVERAGE_CLASS: u16 = 89;
 // const NL80211_ATTR_TX_RATES:u16 = 90;
-// const NL80211_ATTR_FRAME_MATCH:u16 = 91;
-// const NL80211_ATTR_ACK:u16 = 92;
+const NL80211_ATTR_FRAME_MATCH: u16 = 91;
+const NL80211_ATTR_ACK: u16 = 92;
 // const NL80211_ATTR_PS_STATE:u16 = 93;
 // const NL80211_ATTR_CQM:u16 = 94;
 // const NL80211_ATTR_LOCAL_STATE_CHANGE:u16 = 95;
@@ -220,8 +284,9 @@ const NL80211_ATTR_WIPHY_COVERAGE_CLASS: u16 = 89;
 const NL80211_ATTR_WIPHY_TX_POWER_LEVEL: u16 = 98;
 const NL80211_ATTR_TX_FRAME_TYPES: u16 = 99;
 const NL80211_ATTR_RX_FRAME_TYPES: u16 = 100;
-// Covered by frame_type.rs
-// const NL80211_ATTR_FRAME_TYPE:u16 = 101;
+// Also used as a nested sub-attribute of NL80211_ATTR_{TX,RX}_FRAME_TYPES,
+// see frame_type.rs.
+pub(crate) const NL80211_ATTR_FRAME_TYPE: u16 = 101;
 const NL80211_ATTR_CONTROL_PORT_ETHERTYPE: u16 = 102;
 // const NL80211_ATTR_CONTROL_PORT_NO_ENCRYPT:u16 = 103;
 const NL80211_ATTR_SUPPORT_IBSS_RSN: u16 = 104;
@@ -324,7 +389,7 @@ const NL80211_ATTR_VENDOR_DATA: u16 = 197;
 // const NL80211_ATTR_WIPHY_FREQ_HINT:u16 = 201;
 // const NL80211_ATTR_MAX_AP_ASSOC_STA:u16 = 202;
 // const NL80211_ATTR_TDLS_PEER_CAPABILITY:u16 = 203;
-// const NL80211_ATTR_SOCKET_OWNER:u16 = 204;
+const NL80211_ATTR_SOCKET_OWNER: u16 = 204;
 // const NL80211_ATTR_CSA_C_OFFSETS_TX:u16 = 205;
 const NL80211_ATTR_MAX_CSA_COUNTERS: u16 = 206;
 // const NL80211_ATTR_TDLS_INITIATOR:u16 = 207;
@@ -365,7 +430,7 @@ const NL80211_ATTR_BANDS: u16 = 239;
 // const NL80211_ATTR_FILS_KEK:u16 = 242;
 // const NL80211_ATTR_FILS_NONCES:u16 = 243;
 // const NL80211_ATTR_MULTICAST_TO_UNICAST_ENABLED:u16 = 244;
-// const NL80211_ATTR_BSSID:u16 = 245;
+const NL80211_ATTR_BSSID: u16 = 245;
 // const NL80211_ATTR_SCHED_SCAN_RELATIVE_RSSI:u16 = 246;
 // const NL80211_ATTR_SCHED_SCAN_RSSI_ADJUST:u16 = 247;
 // const NL80211_ATTR_TIMEOUT_REASON:u16 = 248;
@@ -380,11 +445,11 @@ const NL80211_ATTR_SCHED_SCAN_MAX_REQS: u16 = 256;
 // const NL80211_ATTR_WANT_1X_4WAY_HS:u16 = 257;
 // const NL80211_ATTR_PMKR0_NAME:u16 = 258;
 // const NL80211_ATTR_PORT_AUTHORIZED:u16 = 259;
-// const NL80211_ATTR_EXTERNAL_AUTH_ACTION:u16 = 260;
-// const NL80211_ATTR_EXTERNAL_AUTH_SUPPORT:u16 = 261;
+const NL80211_ATTR_EXTERNAL_AUTH_ACTION: u16 = 260;
+const NL80211_ATTR_EXTERNAL_AUTH_SUPPORT: u16 = 261;
 // const NL80211_ATTR_NSS:u16 = 262;
 // const NL80211_ATTR_ACK_SIGNAL:u16 = 263;
-// const NL80211_ATTR_CONTROL_PORT_OVER_NL80211:u16 = 264;
+const NL80211_ATTR_CONTROL_PORT_OVER_NL80211: u16 = 264;
 const NL80211_ATTR_TXQ_STATS: u16 = 265;
 const NL80211_ATTR_TXQ_LIMIT: u16 = 266;
 const NL80211_ATTR_TXQ_MEMORY_LIMIT: u16 = 267;
@@ -577,6 +642,66 @@ pub enum Nl80211Attr {
     /// iterations, only the interval between scans. The scan plans are
     /// executed sequentially.
     SchedScanPlans(Vec<Nl80211SchedScanPlan>),
+    /// Authentication type. Used by the `NL80211_CMD_CONNECT` and
+    /// `NL80211_CMD_AUTHENTICATE` commands.
+    AuthType(Nl80211AuthType),
+    /// IEEE 802.11 reason code for `NL80211_CMD_DISCONNECT` /
+    /// `NL80211_CMD_DEAUTHENTICATE`. Default is unspecified (3).
+    ReasonCode(u16),
+    /// IEEE 802.11 status code reported by the access point, e.g. as part of
+    /// the result of a `NL80211_CMD_CONNECT`.
+    StatusCode(u16),
+    /// Whether management frame protection (IEEE 802.11w) is used for the
+    /// connection. Mandatory for WPA3.
+    UseMfp(Nl80211UseMfp),
+    /// Flag attribute, set when connecting to a privacy-enabled (encrypted)
+    /// BSS.
+    Privacy,
+    /// Used with `NL80211_CMD_CONNECT` to indicate which WPA/RSN version(s)
+    /// are enabled.
+    WpaVersions(Nl80211WpaVersions),
+    /// Unicast (pairwise) cipher suites used for the connection.
+    CiphersPairwise(Vec<Nl80211CipherSuite>),
+    /// Group (broadcast/multicast) cipher suite used for the connection.
+    CipherGroup(Nl80211CipherSuite),
+    /// Authentication and Key Management (AKM) suites used for the connection,
+    /// e.g. SAE for WPA3-Personal.
+    AkmSuites(Vec<Nl80211AkmSuite>),
+    /// Raw information element(s) (e.g. an RSN element) to be added to the
+    /// (re)association request.
+    Ie(Vec<u8>),
+    /// A full IEEE 802.11 management frame (e.g. an SAE Authentication frame)
+    /// to transmit with `NL80211_CMD_FRAME`, or as received from the kernel.
+    Frame(Vec<u8>),
+    /// Prefix to match the start of received management frames against, used
+    /// when registering for frames with `NL80211_CMD_REGISTER_FRAME`.
+    FrameMatch(Vec<u8>),
+    /// IEEE 802.11 frame type/subtype to register for / that a frame belongs
+    /// to (the 16-bit frame control type+subtype field).
+    FrameType(u16),
+    /// Cookie identifying a transmitted management frame, used to correlate a
+    /// `NL80211_CMD_FRAME` request with its `NL80211_CMD_FRAME_TX_STATUS`.
+    Cookie(u64),
+    /// Flag attribute present in a frame TX status to indicate the frame was
+    /// acknowledged by the peer.
+    Ack,
+    /// BSSID, used with `NL80211_CMD_EXTERNAL_AUTH` (distinct from the generic
+    /// `NL80211_ATTR_MAC`).
+    Bssid([u8; ETH_ALEN]),
+    /// External authentication action (start/abort), used with
+    /// `NL80211_CMD_EXTERNAL_AUTH`.
+    ExternalAuthAction(Nl80211ExternalAuthAction),
+    /// Flag attribute set on `NL80211_CMD_CONNECT` to indicate that userspace
+    /// will perform the authentication (e.g. SAE) externally, via
+    /// `NL80211_CMD_EXTERNAL_AUTH`.
+    ExternalAuthSupport,
+    /// Flag attribute requesting that the EAPOL (802.1X) control port frames
+    /// are sent and received over nl80211 instead of a network interface.
+    ControlPortOverNl80211,
+    /// Flag attribute indicating that the netlink socket owning this request
+    /// owns the created object (e.g. the connection), so it is destroyed when
+    /// the socket is closed.
+    SocketOwner,
     Other(DefaultNla),
     /// 24-bit OUI, or an as yet unused Linux-specific ID.
     ///
@@ -691,6 +816,20 @@ impl Nla for Nl80211Attr {
             }
             Self::SchedScanMatch(v) => v.as_slice().buffer_len(),
             Self::SchedScanPlans(v) => v.as_slice().buffer_len(),
+            Self::AuthType(_) | Self::UseMfp(_) | Self::WpaVersions(_) => 4,
+            Self::ExternalAuthAction(_) => 4,
+            Self::ReasonCode(_) | Self::StatusCode(_) | Self::FrameType(_) => 2,
+            Self::Cookie(_) => 8,
+            Self::Privacy
+            | Self::ControlPortOverNl80211
+            | Self::ExternalAuthSupport
+            | Self::Ack
+            | Self::SocketOwner => 0,
+            Self::CiphersPairwise(s) => 4 * s.len(),
+            Self::CipherGroup(_) => 4,
+            Self::AkmSuites(s) => 4 * s.len(),
+            Self::Bssid(_) => ETH_ALEN,
+            Self::Ie(v) | Self::Frame(v) | Self::FrameMatch(v) => v.len(),
             Self::Other(attr) => attr.value_len(),
             Self::VendorData(d) => d.len(),
         }
@@ -803,6 +942,28 @@ impl Nla for Nl80211Attr {
             Self::VendorId(_) => NL80211_ATTR_VENDOR_ID,
             Self::VendorSubcmd(_) => NL80211_ATTR_VENDOR_SUBCMD,
             Self::VendorData(_) => NL80211_ATTR_VENDOR_DATA,
+            Self::AuthType(_) => NL80211_ATTR_AUTH_TYPE,
+            Self::ReasonCode(_) => NL80211_ATTR_REASON_CODE,
+            Self::StatusCode(_) => NL80211_ATTR_STATUS_CODE,
+            Self::UseMfp(_) => NL80211_ATTR_USE_MFP,
+            Self::Privacy => NL80211_ATTR_PRIVACY,
+            Self::WpaVersions(_) => NL80211_ATTR_WPA_VERSIONS,
+            Self::CiphersPairwise(_) => NL80211_ATTR_CIPHER_SUITES_PAIRWISE,
+            Self::CipherGroup(_) => NL80211_ATTR_CIPHER_SUITE_GROUP,
+            Self::AkmSuites(_) => NL80211_ATTR_AKM_SUITES,
+            Self::Ie(_) => NL80211_ATTR_IE,
+            Self::Frame(_) => NL80211_ATTR_FRAME,
+            Self::FrameMatch(_) => NL80211_ATTR_FRAME_MATCH,
+            Self::FrameType(_) => NL80211_ATTR_FRAME_TYPE,
+            Self::Cookie(_) => NL80211_ATTR_COOKIE,
+            Self::Ack => NL80211_ATTR_ACK,
+            Self::Bssid(_) => NL80211_ATTR_BSSID,
+            Self::ExternalAuthAction(_) => NL80211_ATTR_EXTERNAL_AUTH_ACTION,
+            Self::ExternalAuthSupport => NL80211_ATTR_EXTERNAL_AUTH_SUPPORT,
+            Self::ControlPortOverNl80211 => {
+                NL80211_ATTR_CONTROL_PORT_OVER_NL80211
+            }
+            Self::SocketOwner => NL80211_ATTR_SOCKET_OWNER,
             Self::Other(attr) => attr.kind(),
         }
     }
@@ -924,6 +1085,45 @@ impl Nla for Nl80211Attr {
             Self::SchedScanMatch(v) => v.as_slice().emit(buffer),
             Self::SchedScanPlans(v) => v.as_slice().emit(buffer),
             Self::VendorData(v) => buffer.copy_from_slice(v),
+            Self::AuthType(d) => write_u32(buffer, u32::from(*d)),
+            Self::UseMfp(d) => write_u32(buffer, u32::from(*d)),
+            Self::WpaVersions(d) => write_u32(buffer, d.bits()),
+            Self::ReasonCode(d) | Self::StatusCode(d) => write_u16(buffer, *d),
+            Self::FrameType(d) => write_u16(buffer, *d),
+            Self::Cookie(d) => write_u64(buffer, *d),
+            Self::ExternalAuthAction(d) => write_u32(buffer, u32::from(*d)),
+            Self::Privacy
+            | Self::ControlPortOverNl80211
+            | Self::ExternalAuthSupport
+            | Self::Ack
+            | Self::SocketOwner => (),
+            Self::CiphersPairwise(suits) => {
+                // `.swap_bytes()` converts our byte-reversed internal value
+                // (`0x04ac0f00`) back to the kernel's OUI constant
+                // (`0x000fac04`); `to_ne_bytes` then lays it out in native
+                // order to match the kernel's `nla_put_u32` wire format on any
+                // host. See `parse_cipher_suites` for the full rationale.
+                for (i, c) in suits.iter().enumerate() {
+                    buffer[i * 4..(i + 1) * 4].copy_from_slice(
+                        &u32::from(*c).swap_bytes().to_ne_bytes(),
+                    );
+                }
+            }
+            // Same byte-swap + native-order encoding as the pairwise ciphers.
+            Self::CipherGroup(c) => buffer[..4]
+                .copy_from_slice(&u32::from(*c).swap_bytes().to_ne_bytes()),
+            Self::AkmSuites(suits) => {
+                // Same byte-swap + native-order encoding as cipher suites.
+                for (i, a) in suits.iter().enumerate() {
+                    buffer[i * 4..(i + 1) * 4].copy_from_slice(
+                        &u32::from(*a).swap_bytes().to_ne_bytes(),
+                    );
+                }
+            }
+            Self::Bssid(d) => buffer[..ETH_ALEN].copy_from_slice(d),
+            Self::Ie(v) | Self::Frame(v) | Self::FrameMatch(v) => {
+                buffer[..v.len()].copy_from_slice(v)
+            }
             Self::Other(attr) => attr.emit(buffer),
         }
     }
@@ -1480,6 +1680,101 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nl80211Attr {
                 ))?)
             }
             NL80211_ATTR_VENDOR_DATA => Self::VendorData(payload.to_vec()),
+            NL80211_ATTR_AUTH_TYPE => {
+                let err_msg =
+                    format!("Invalid NL80211_ATTR_AUTH_TYPE value {payload:?}");
+                Self::AuthType(Nl80211AuthType::from(
+                    parse_u32(payload).context(err_msg)?,
+                ))
+            }
+            NL80211_ATTR_REASON_CODE => {
+                let err_msg = format!(
+                    "Invalid NL80211_ATTR_REASON_CODE value {payload:?}"
+                );
+                Self::ReasonCode(parse_u16(payload).context(err_msg)?)
+            }
+            NL80211_ATTR_STATUS_CODE => {
+                let err_msg = format!(
+                    "Invalid NL80211_ATTR_STATUS_CODE value {payload:?}"
+                );
+                Self::StatusCode(parse_u16(payload).context(err_msg)?)
+            }
+            NL80211_ATTR_USE_MFP => {
+                let err_msg =
+                    format!("Invalid NL80211_ATTR_USE_MFP value {payload:?}");
+                Self::UseMfp(Nl80211UseMfp::from(
+                    parse_u32(payload).context(err_msg)?,
+                ))
+            }
+            NL80211_ATTR_PRIVACY => Self::Privacy,
+            NL80211_ATTR_WPA_VERSIONS => {
+                let err_msg = format!(
+                    "Invalid NL80211_ATTR_WPA_VERSIONS value {payload:?}"
+                );
+                Self::WpaVersions(Nl80211WpaVersions::from_bits_retain(
+                    parse_u32(payload).context(err_msg)?,
+                ))
+            }
+            NL80211_ATTR_CIPHER_SUITES_PAIRWISE => {
+                Self::CiphersPairwise(parse_cipher_suites(payload)?)
+            }
+            NL80211_ATTR_CIPHER_SUITE_GROUP => {
+                if payload.len() != 4 {
+                    return Err(format!(
+                        "Invalid NL80211_ATTR_CIPHER_SUITE_GROUP length {}, \
+                        expecting 4",
+                        payload.len()
+                    )
+                    .into());
+                }
+                // `.swap_bytes()` bridges the kernel's native-endian OUI
+                // constant and our byte-reversed representation; see
+                // `parse_cipher_suites` for the full rationale.
+                Self::CipherGroup(Nl80211CipherSuite::from(
+                    u32::from_ne_bytes(payload.try_into().unwrap())
+                        .swap_bytes(),
+                ))
+            }
+            NL80211_ATTR_AKM_SUITES => {
+                Self::AkmSuites(parse_akm_suites(payload)?)
+            }
+            NL80211_ATTR_IE => Self::Ie(payload.to_vec()),
+            NL80211_ATTR_FRAME => Self::Frame(payload.to_vec()),
+            NL80211_ATTR_FRAME_MATCH => Self::FrameMatch(payload.to_vec()),
+            NL80211_ATTR_FRAME_TYPE => {
+                let err_msg = format!(
+                    "Invalid NL80211_ATTR_FRAME_TYPE value {payload:?}"
+                );
+                Self::FrameType(parse_u16(payload).context(err_msg)?)
+            }
+            NL80211_ATTR_COOKIE => {
+                let err_msg =
+                    format!("Invalid NL80211_ATTR_COOKIE value {payload:?}");
+                Self::Cookie(parse_u64(payload).context(err_msg)?)
+            }
+            NL80211_ATTR_ACK => Self::Ack,
+            NL80211_ATTR_BSSID => {
+                Self::Bssid(payload.try_into().map_err(|_| {
+                    format!(
+                        "Invalid length of NL80211_ATTR_BSSID, \
+                        expected length {ETH_ALEN} got {payload:?}"
+                    )
+                })?)
+            }
+            NL80211_ATTR_EXTERNAL_AUTH_ACTION => {
+                let err_msg = format!(
+                    "Invalid NL80211_ATTR_EXTERNAL_AUTH_ACTION value \
+                    {payload:?}"
+                );
+                Self::ExternalAuthAction(Nl80211ExternalAuthAction::from(
+                    parse_u32(payload).context(err_msg)?,
+                ))
+            }
+            NL80211_ATTR_EXTERNAL_AUTH_SUPPORT => Self::ExternalAuthSupport,
+            NL80211_ATTR_CONTROL_PORT_OVER_NL80211 => {
+                Self::ControlPortOverNl80211
+            }
+            NL80211_ATTR_SOCKET_OWNER => Self::SocketOwner,
             _ => Self::Other(
                 DefaultNla::parse(buf).context("invalid NLA (unknown kind)")?,
             ),

--- a/src/connect/disconnect.rs
+++ b/src/connect/disconnect.rs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+
+use futures::TryStream;
+use netlink_packet_core::{NLM_F_ACK, NLM_F_REQUEST};
+use netlink_packet_generic::GenlMessage;
+
+use crate::{
+    nl80211_execute, Nl80211Attr, Nl80211AttrsBuilder, Nl80211Command,
+    Nl80211Error, Nl80211Handle, Nl80211Message,
+};
+
+/// IEEE 802.11 reason code "Deauthenticated because sending STA is leaving"
+/// (3), the default used when disconnecting.
+const WLAN_REASON_DEAUTH_LEAVING: u16 = 3;
+
+/// Helper to build the attribute list for a `NL80211_CMD_DISCONNECT` request.
+#[derive(Debug)]
+pub struct Nl80211Disconnect;
+
+impl Nl80211Disconnect {
+    /// Start building a disconnect request for the interface `if_index`.
+    /// Defaults the reason code to "STA is leaving".
+    pub fn new(if_index: u32) -> Nl80211AttrsBuilder<Self> {
+        Nl80211AttrsBuilder::<Self>::new()
+            .if_index(if_index)
+            .reason_code(WLAN_REASON_DEAUTH_LEAVING)
+    }
+}
+
+impl Nl80211AttrsBuilder<Nl80211Disconnect> {
+    /// IEEE 802.11 reason code to report to the AP.
+    pub fn reason_code(self, reason: u16) -> Self {
+        self.replace(Nl80211Attr::ReasonCode(reason))
+    }
+}
+
+pub struct Nl80211DisconnectRequest {
+    handle: Nl80211Handle,
+    attributes: Vec<Nl80211Attr>,
+}
+
+impl Nl80211DisconnectRequest {
+    pub(crate) fn new(
+        handle: Nl80211Handle,
+        attributes: Vec<Nl80211Attr>,
+    ) -> Self {
+        Nl80211DisconnectRequest { handle, attributes }
+    }
+
+    /// Send the `NL80211_CMD_DISCONNECT` request.
+    pub async fn execute(
+        self,
+    ) -> impl TryStream<Ok = GenlMessage<Nl80211Message>, Error = Nl80211Error>
+    {
+        let Nl80211DisconnectRequest {
+            mut handle,
+            attributes,
+        } = self;
+
+        let nl80211_msg = Nl80211Message {
+            cmd: Nl80211Command::Disconnect,
+            attributes,
+        };
+        let flags = NLM_F_REQUEST | NLM_F_ACK;
+
+        nl80211_execute(&mut handle, nl80211_msg, flags).await
+    }
+}

--- a/src/connect/external_auth.rs
+++ b/src/connect/external_auth.rs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+
+use futures::TryStream;
+use netlink_packet_core::{NLM_F_ACK, NLM_F_REQUEST};
+use netlink_packet_generic::GenlMessage;
+
+use crate::{
+    nl80211_execute, Nl80211Attr, Nl80211AttrsBuilder, Nl80211Command,
+    Nl80211Error, Nl80211Handle, Nl80211Message,
+};
+
+/// Helper to build the attribute list for a `NL80211_CMD_EXTERNAL_AUTH`
+/// request, used by userspace to report the result of an externally performed
+/// authentication (e.g. SAE) back to the kernel.
+///
+/// The kernel requires [`ssid`](Nl80211AttrsBuilder::ssid),
+/// [`bssid`](Nl80211AttrsBuilder::<Nl80211ExternalAuth>::bssid) and
+/// [`status_code`](Nl80211AttrsBuilder::<Nl80211ExternalAuth>::status_code)
+/// to be set.
+#[derive(Debug)]
+pub struct Nl80211ExternalAuth;
+
+impl Nl80211ExternalAuth {
+    /// Start building an external-auth result for the interface `if_index`.
+    pub fn new(if_index: u32) -> Nl80211AttrsBuilder<Self> {
+        Nl80211AttrsBuilder::<Self>::new().if_index(if_index)
+    }
+}
+
+impl Nl80211AttrsBuilder<Nl80211ExternalAuth> {
+    /// BSSID of the AP the authentication was performed with.
+    pub fn bssid(self, bssid: [u8; 6]) -> Self {
+        self.replace(Nl80211Attr::Bssid(bssid))
+    }
+
+    /// IEEE 802.11 status code of the authentication (0 means success).
+    pub fn status_code(self, status: u16) -> Self {
+        self.replace(Nl80211Attr::StatusCode(status))
+    }
+}
+
+pub struct Nl80211ExternalAuthRequest {
+    handle: Nl80211Handle,
+    attributes: Vec<Nl80211Attr>,
+}
+
+impl Nl80211ExternalAuthRequest {
+    pub(crate) fn new(
+        handle: Nl80211Handle,
+        attributes: Vec<Nl80211Attr>,
+    ) -> Self {
+        Nl80211ExternalAuthRequest { handle, attributes }
+    }
+
+    /// Send the `NL80211_CMD_EXTERNAL_AUTH` request.
+    pub async fn execute(
+        self,
+    ) -> impl TryStream<Ok = GenlMessage<Nl80211Message>, Error = Nl80211Error>
+    {
+        let Nl80211ExternalAuthRequest {
+            mut handle,
+            attributes,
+        } = self;
+
+        let nl80211_msg = Nl80211Message {
+            cmd: Nl80211Command::ExternalAuth,
+            attributes,
+        };
+        let flags = NLM_F_REQUEST | NLM_F_ACK;
+
+        nl80211_execute(&mut handle, nl80211_msg, flags).await
+    }
+}

--- a/src/connect/frame.rs
+++ b/src/connect/frame.rs
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: MIT
+
+use futures::TryStream;
+use netlink_packet_core::{NLM_F_ACK, NLM_F_REQUEST};
+use netlink_packet_generic::GenlMessage;
+
+use crate::{
+    nl80211_execute, Nl80211Attr, Nl80211AttrsBuilder, Nl80211Command,
+    Nl80211Error, Nl80211Handle, Nl80211Message,
+};
+
+/// Helper to build the attribute list for a `NL80211_CMD_FRAME` request, used
+/// to transmit a management frame (e.g. an SAE Authentication frame during
+/// external authentication).
+///
+/// The kernel requires the raw
+/// [`frame`](Nl80211AttrsBuilder::<Nl80211Frame>::frame) and, unless
+/// transmitting on the current operating channel, the
+/// [`frequency`](Nl80211AttrsBuilder::<Nl80211Frame>::frequency).
+#[derive(Debug)]
+pub struct Nl80211Frame;
+
+impl Nl80211Frame {
+    /// Start building a frame transmit request for the interface `if_index`.
+    pub fn new(if_index: u32) -> Nl80211AttrsBuilder<Self> {
+        Nl80211AttrsBuilder::<Self>::new().if_index(if_index)
+    }
+}
+
+impl Nl80211AttrsBuilder<Nl80211Frame> {
+    /// Channel frequency in MHz to transmit the frame on.
+    pub fn frequency(self, freq_mhz: u32) -> Self {
+        self.replace(Nl80211Attr::WiphyFreq(freq_mhz))
+    }
+
+    /// The raw IEEE 802.11 management frame to transmit.
+    pub fn frame(self, frame: Vec<u8>) -> Self {
+        self.replace(Nl80211Attr::Frame(frame))
+    }
+}
+
+pub struct Nl80211FrameRequest {
+    handle: Nl80211Handle,
+    attributes: Vec<Nl80211Attr>,
+}
+
+impl Nl80211FrameRequest {
+    pub(crate) fn new(
+        handle: Nl80211Handle,
+        attributes: Vec<Nl80211Attr>,
+    ) -> Self {
+        Nl80211FrameRequest { handle, attributes }
+    }
+
+    /// Send the `NL80211_CMD_FRAME` request.
+    ///
+    /// On success the kernel replies with a message carrying the
+    /// `NL80211_ATTR_COOKIE` identifying the transmitted frame, which can be
+    /// matched against the later `NL80211_CMD_FRAME_TX_STATUS` event.
+    pub async fn execute(
+        self,
+    ) -> impl TryStream<Ok = GenlMessage<Nl80211Message>, Error = Nl80211Error>
+    {
+        let Nl80211FrameRequest {
+            mut handle,
+            attributes,
+        } = self;
+
+        let nl80211_msg = Nl80211Message {
+            cmd: Nl80211Command::Frame,
+            attributes,
+        };
+        let flags = NLM_F_REQUEST | NLM_F_ACK;
+
+        nl80211_execute(&mut handle, nl80211_msg, flags).await
+    }
+}
+
+/// Helper to build the attribute list for a `NL80211_CMD_REGISTER_FRAME`
+/// request, used to register the calling socket to receive management frames
+/// of a given type (e.g. Authentication frames during external SAE).
+///
+/// Registration is per-socket: the frames are delivered on the same socket
+/// that sent the registration, which must therefore stay open.
+#[derive(Debug)]
+pub struct Nl80211RegisterFrame;
+
+impl Nl80211RegisterFrame {
+    /// Start building a frame registration for the interface `if_index`.
+    ///
+    /// Defaults the match prefix to empty (match all frames of the registered
+    /// type); the kernel requires the match attribute to be present.
+    pub fn new(if_index: u32) -> Nl80211AttrsBuilder<Self> {
+        Nl80211AttrsBuilder::<Self>::new()
+            .if_index(if_index)
+            .frame_match(Vec::new())
+    }
+}
+
+impl Nl80211AttrsBuilder<Nl80211RegisterFrame> {
+    /// IEEE 802.11 frame control type/subtype field to register for (e.g.
+    /// `0x00b0` for a Management/Authentication frame).
+    pub fn frame_type(self, frame_type: u16) -> Self {
+        self.replace(Nl80211Attr::FrameType(frame_type))
+    }
+
+    /// Byte prefix that received frames must match. An empty match registers
+    /// for all frames of the given type.
+    pub fn frame_match(self, prefix: Vec<u8>) -> Self {
+        self.replace(Nl80211Attr::FrameMatch(prefix))
+    }
+}
+
+pub struct Nl80211RegisterFrameRequest {
+    handle: Nl80211Handle,
+    attributes: Vec<Nl80211Attr>,
+}
+
+impl Nl80211RegisterFrameRequest {
+    pub(crate) fn new(
+        handle: Nl80211Handle,
+        attributes: Vec<Nl80211Attr>,
+    ) -> Self {
+        Nl80211RegisterFrameRequest { handle, attributes }
+    }
+
+    /// Send the `NL80211_CMD_REGISTER_FRAME` request.
+    pub async fn execute(
+        self,
+    ) -> impl TryStream<Ok = GenlMessage<Nl80211Message>, Error = Nl80211Error>
+    {
+        let Nl80211RegisterFrameRequest {
+            mut handle,
+            attributes,
+        } = self;
+
+        let nl80211_msg = Nl80211Message {
+            cmd: Nl80211Command::RegisterFrame,
+            attributes,
+        };
+        let flags = NLM_F_REQUEST | NLM_F_ACK;
+
+        nl80211_execute(&mut handle, nl80211_msg, flags).await
+    }
+}

--- a/src/connect/handle.rs
+++ b/src/connect/handle.rs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+
+use crate::{
+    Nl80211Attr, Nl80211ConnectRequest, Nl80211DisconnectRequest,
+    Nl80211ExternalAuthRequest, Nl80211FrameRequest, Nl80211Handle,
+    Nl80211RegisterFrameRequest,
+};
+
+/// A handle to send connection management commands (`NL80211_CMD_CONNECT` and
+/// `NL80211_CMD_DISCONNECT`) for a station (managed) interface.
+#[derive(Debug, Clone)]
+pub struct Nl80211ConnectionHandle(Nl80211Handle);
+
+impl Nl80211ConnectionHandle {
+    pub fn new(handle: Nl80211Handle) -> Self {
+        Nl80211ConnectionHandle(handle)
+    }
+
+    /// Request a connection (equivalent to `iw dev DEVICE connect`).
+    ///
+    /// The `attributes` are normally produced by [`crate::Nl80211Connect`],
+    /// for example:
+    ///
+    /// ```no_run
+    /// use wl_nl80211::Nl80211Connect;
+    ///
+    /// let if_index = 0u32;
+    /// let attrs = Nl80211Connect::new(if_index)
+    ///     .ssid("Test-WIFI")
+    ///     .wpa3_personal()
+    ///     .build();
+    /// # let _ = attrs;
+    /// ```
+    pub fn connect(
+        &mut self,
+        attributes: Vec<Nl80211Attr>,
+    ) -> Nl80211ConnectRequest {
+        Nl80211ConnectRequest::new(self.0.clone(), attributes)
+    }
+
+    /// Request a disconnection (equivalent to `iw dev DEVICE disconnect`).
+    ///
+    /// The `attributes` are normally produced by [`crate::Nl80211Disconnect`].
+    pub fn disconnect(
+        &mut self,
+        attributes: Vec<Nl80211Attr>,
+    ) -> Nl80211DisconnectRequest {
+        Nl80211DisconnectRequest::new(self.0.clone(), attributes)
+    }
+
+    /// Report the result of an externally performed authentication
+    /// (`NL80211_CMD_EXTERNAL_AUTH`), e.g. the outcome of a userspace SAE
+    /// exchange.
+    ///
+    /// The `attributes` are normally produced by
+    /// [`crate::Nl80211ExternalAuth`].
+    pub fn external_auth(
+        &mut self,
+        attributes: Vec<Nl80211Attr>,
+    ) -> Nl80211ExternalAuthRequest {
+        Nl80211ExternalAuthRequest::new(self.0.clone(), attributes)
+    }
+
+    /// Transmit a management frame (`NL80211_CMD_FRAME`), e.g. an SAE
+    /// Authentication frame.
+    ///
+    /// The `attributes` are normally produced by [`crate::Nl80211Frame`].
+    pub fn frame(
+        &mut self,
+        attributes: Vec<Nl80211Attr>,
+    ) -> Nl80211FrameRequest {
+        Nl80211FrameRequest::new(self.0.clone(), attributes)
+    }
+
+    /// Register the calling socket to receive management frames of a given
+    /// type (`NL80211_CMD_REGISTER_FRAME`).
+    ///
+    /// The `attributes` are normally produced by
+    /// [`crate::Nl80211RegisterFrame`]. Note that frames are delivered on the
+    /// socket backing this handle, which must stay open to receive them.
+    pub fn register_frame(
+        &mut self,
+        attributes: Vec<Nl80211Attr>,
+    ) -> Nl80211RegisterFrameRequest {
+        Nl80211RegisterFrameRequest::new(self.0.clone(), attributes)
+    }
+}

--- a/src/connect/mod.rs
+++ b/src/connect/mod.rs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+
+mod disconnect;
+mod external_auth;
+mod frame;
+mod handle;
+mod request;
+mod types;
+
+pub use self::disconnect::{Nl80211Disconnect, Nl80211DisconnectRequest};
+pub use self::external_auth::{
+    Nl80211ExternalAuth, Nl80211ExternalAuthRequest,
+};
+pub use self::frame::{
+    Nl80211Frame, Nl80211FrameRequest, Nl80211RegisterFrame,
+    Nl80211RegisterFrameRequest,
+};
+pub use self::handle::Nl80211ConnectionHandle;
+pub use self::request::{Nl80211Connect, Nl80211ConnectRequest};
+pub use self::types::{
+    Nl80211AuthType, Nl80211ExternalAuthAction, Nl80211UseMfp,
+    Nl80211WpaVersions,
+};

--- a/src/connect/request.rs
+++ b/src/connect/request.rs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: MIT
+
+use futures::TryStream;
+use netlink_packet_core::{Nla, NLM_F_ACK, NLM_F_REQUEST};
+use netlink_packet_generic::GenlMessage;
+
+use crate::{
+    nl80211_execute, Nl80211AkmSuite, Nl80211Attr, Nl80211AttrsBuilder,
+    Nl80211AuthType, Nl80211CipherSuite, Nl80211Command, Nl80211Error,
+    Nl80211Handle, Nl80211Message, Nl80211UseMfp, Nl80211WpaVersions,
+};
+
+/// Helper to build the attribute list for a `NL80211_CMD_CONNECT` request.
+///
+/// For a typical WPA3-Personal (userspace SAE / external auth) connection use
+/// [`Nl80211AttrsBuilder::<Nl80211Connect>::wpa3_personal`].
+#[derive(Debug)]
+pub struct Nl80211Connect;
+
+impl Nl80211Connect {
+    /// Start building a connect request for the interface `if_index`.
+    pub fn new(if_index: u32) -> Nl80211AttrsBuilder<Self> {
+        Nl80211AttrsBuilder::<Self>::new().if_index(if_index)
+    }
+}
+
+impl Nl80211AttrsBuilder<Nl80211Connect> {
+    /// Restrict the connection to a specific BSSID.
+    ///
+    /// Uses `NL80211_ATTR_MAC` (not `NL80211_ATTR_BSSID`, which is used by
+    /// `NL80211_CMD_EXTERNAL_AUTH`), matching the kernel's convention for
+    /// `NL80211_CMD_CONNECT`.
+    pub fn mac(self, mac: [u8; 6]) -> Self {
+        self.replace(Nl80211Attr::Mac(mac))
+    }
+
+    /// Channel frequency hint in MHz.
+    pub fn frequency(self, freq_mhz: u32) -> Self {
+        self.replace(Nl80211Attr::WiphyFreq(freq_mhz))
+    }
+
+    /// Authentication type, e.g. [`Nl80211AuthType::Sae`] for WPA3-Personal.
+    pub fn auth_type(self, auth_type: Nl80211AuthType) -> Self {
+        self.replace(Nl80211Attr::AuthType(auth_type))
+    }
+
+    /// Enabled WPA/RSN version(s).
+    pub fn wpa_versions(self, versions: Nl80211WpaVersions) -> Self {
+        self.replace(Nl80211Attr::WpaVersions(versions))
+    }
+
+    /// Unicast (pairwise) cipher suite(s).
+    pub fn ciphers_pairwise(self, ciphers: Vec<Nl80211CipherSuite>) -> Self {
+        self.replace(Nl80211Attr::CiphersPairwise(ciphers))
+    }
+
+    /// Group (broadcast/multicast) cipher suite.
+    pub fn cipher_group(self, cipher: Nl80211CipherSuite) -> Self {
+        self.replace(Nl80211Attr::CipherGroup(cipher))
+    }
+
+    /// Authentication and Key Management (AKM) suite(s).
+    pub fn akm_suites(self, akms: Vec<Nl80211AkmSuite>) -> Self {
+        self.replace(Nl80211Attr::AkmSuites(akms))
+    }
+
+    /// Indicate that userspace will perform the authentication (e.g. SAE)
+    /// externally. The kernel/driver will emit a `NL80211_CMD_EXTERNAL_AUTH`
+    /// event to drive the exchange. This is the portable path for
+    /// WPA3-Personal on drivers that do not advertise SAE offload.
+    pub fn external_auth_support(self, enable: bool) -> Self {
+        if enable {
+            self.replace(Nl80211Attr::ExternalAuthSupport)
+        } else {
+            self.remove(Nl80211Attr::ExternalAuthSupport.kind())
+        }
+    }
+
+    /// Whether the target BSS is privacy-enabled (encrypted).
+    pub fn privacy(self, enable: bool) -> Self {
+        if enable {
+            self.replace(Nl80211Attr::Privacy)
+        } else {
+            self.remove(Nl80211Attr::Privacy.kind())
+        }
+    }
+
+    /// Management frame protection (IEEE 802.11w) mode.
+    pub fn use_mfp(self, mfp: Nl80211UseMfp) -> Self {
+        self.replace(Nl80211Attr::UseMfp(mfp))
+    }
+
+    /// Request that EAPOL (802.1X) control port frames are sent/received over
+    /// nl80211. When enabled, [`socket_owner`](Self::socket_owner) must also
+    /// be set.
+    pub fn control_port_over_nl80211(self, enable: bool) -> Self {
+        if enable {
+            self.replace(Nl80211Attr::ControlPortOverNl80211)
+        } else {
+            self.remove(Nl80211Attr::ControlPortOverNl80211.kind())
+        }
+    }
+
+    /// Mark the requesting socket as the owner of the connection, so it is
+    /// torn down when the socket is closed.
+    pub fn socket_owner(self, enable: bool) -> Self {
+        if enable {
+            self.replace(Nl80211Attr::SocketOwner)
+        } else {
+            self.remove(Nl80211Attr::SocketOwner.kind())
+        }
+    }
+
+    /// Extra information element(s) (e.g. a custom RSN element) to add to the
+    /// association request.
+    pub fn ie(self, ie: Vec<u8>) -> Self {
+        self.replace(Nl80211Attr::Ie(ie))
+    }
+
+    /// Configure all crypto attributes for a standard WPA3-Personal (SAE)
+    /// connection using CCMP-128 and required management frame protection,
+    /// performing the SAE authentication in userspace (external auth).
+    ///
+    /// No password is passed to the kernel; userspace must run the SAE
+    /// exchange in response to the `NL80211_CMD_EXTERNAL_AUTH` event and
+    /// transmit the Authentication frames via `NL80211_CMD_FRAME`.
+    ///
+    /// The caller still needs to set [`ssid`](Self::ssid) (and optionally
+    /// [`mac`](Self::mac)).
+    pub fn wpa3_personal(self) -> Self {
+        self.auth_type(Nl80211AuthType::Sae)
+            .wpa_versions(Nl80211WpaVersions::WPA2)
+            .ciphers_pairwise(vec![Nl80211CipherSuite::Ccmp128])
+            .cipher_group(Nl80211CipherSuite::Ccmp128)
+            .akm_suites(vec![Nl80211AkmSuite::Sae])
+            .use_mfp(Nl80211UseMfp::Required)
+            .privacy(true)
+            .external_auth_support(true)
+    }
+}
+
+pub struct Nl80211ConnectRequest {
+    handle: Nl80211Handle,
+    attributes: Vec<Nl80211Attr>,
+}
+
+impl Nl80211ConnectRequest {
+    pub(crate) fn new(
+        handle: Nl80211Handle,
+        attributes: Vec<Nl80211Attr>,
+    ) -> Self {
+        Nl80211ConnectRequest { handle, attributes }
+    }
+
+    /// Send the `NL80211_CMD_CONNECT` request.
+    ///
+    /// A successful return only means the request was accepted by the kernel;
+    /// the actual connection result is delivered asynchronously as a
+    /// `NL80211_CMD_CONNECT` event on the multicast group.
+    pub async fn execute(
+        self,
+    ) -> impl TryStream<Ok = GenlMessage<Nl80211Message>, Error = Nl80211Error>
+    {
+        let Nl80211ConnectRequest {
+            mut handle,
+            attributes,
+        } = self;
+
+        let nl80211_msg = Nl80211Message {
+            cmd: Nl80211Command::Connect,
+            attributes,
+        };
+        let flags = NLM_F_REQUEST | NLM_F_ACK;
+
+        nl80211_execute(&mut handle, nl80211_msg, flags).await
+    }
+}

--- a/src/connect/types.rs
+++ b/src/connect/types.rs
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: MIT
+
+/// Authentication type, used by `NL80211_CMD_CONNECT` and
+/// `NL80211_CMD_AUTHENTICATE`.
+///
+/// Mirrors the stable values of the kernel `enum nl80211_auth_type`. Values
+/// that are not (yet) modelled here -- including the version-dependent
+/// `NL80211_AUTHTYPE_AUTOMATIC` -- are represented by
+/// [`Nl80211AuthType::Other`].
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
+#[non_exhaustive]
+pub enum Nl80211AuthType {
+    /// Open System authentication.
+    #[default]
+    OpenSystem,
+    /// Shared Key authentication (WEP only).
+    SharedKey,
+    /// Fast BSS Transition (802.11r).
+    Ft,
+    /// Network EAP (Cisco proprietary).
+    NetworkEap,
+    /// Simultaneous Authentication of Equals (WPA3-Personal).
+    Sae,
+    /// Fast Initial Link Setup shared key, without PFS.
+    FilsSk,
+    /// Fast Initial Link Setup shared key, with PFS.
+    FilsSkPfs,
+    /// Fast Initial Link Setup public key.
+    FilsPk,
+    /// Any other / kernel-version-specific value.
+    Other(u32),
+}
+
+const NL80211_AUTHTYPE_OPEN_SYSTEM: u32 = 0;
+const NL80211_AUTHTYPE_SHARED_KEY: u32 = 1;
+const NL80211_AUTHTYPE_FT: u32 = 2;
+const NL80211_AUTHTYPE_NETWORK_EAP: u32 = 3;
+const NL80211_AUTHTYPE_SAE: u32 = 4;
+const NL80211_AUTHTYPE_FILS_SK: u32 = 5;
+const NL80211_AUTHTYPE_FILS_SK_PFS: u32 = 6;
+const NL80211_AUTHTYPE_FILS_PK: u32 = 7;
+
+impl From<u32> for Nl80211AuthType {
+    fn from(d: u32) -> Self {
+        match d {
+            NL80211_AUTHTYPE_OPEN_SYSTEM => Self::OpenSystem,
+            NL80211_AUTHTYPE_SHARED_KEY => Self::SharedKey,
+            NL80211_AUTHTYPE_FT => Self::Ft,
+            NL80211_AUTHTYPE_NETWORK_EAP => Self::NetworkEap,
+            NL80211_AUTHTYPE_SAE => Self::Sae,
+            NL80211_AUTHTYPE_FILS_SK => Self::FilsSk,
+            NL80211_AUTHTYPE_FILS_SK_PFS => Self::FilsSkPfs,
+            NL80211_AUTHTYPE_FILS_PK => Self::FilsPk,
+            _ => Self::Other(d),
+        }
+    }
+}
+
+impl From<Nl80211AuthType> for u32 {
+    fn from(v: Nl80211AuthType) -> u32 {
+        match v {
+            Nl80211AuthType::OpenSystem => NL80211_AUTHTYPE_OPEN_SYSTEM,
+            Nl80211AuthType::SharedKey => NL80211_AUTHTYPE_SHARED_KEY,
+            Nl80211AuthType::Ft => NL80211_AUTHTYPE_FT,
+            Nl80211AuthType::NetworkEap => NL80211_AUTHTYPE_NETWORK_EAP,
+            Nl80211AuthType::Sae => NL80211_AUTHTYPE_SAE,
+            Nl80211AuthType::FilsSk => NL80211_AUTHTYPE_FILS_SK,
+            Nl80211AuthType::FilsSkPfs => NL80211_AUTHTYPE_FILS_SK_PFS,
+            Nl80211AuthType::FilsPk => NL80211_AUTHTYPE_FILS_PK,
+            Nl80211AuthType::Other(d) => d,
+        }
+    }
+}
+
+/// Whether management frame protection (IEEE 802.11w, PMF) is used for a
+/// connection. Mirrors the kernel `enum nl80211_mfp`.
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
+#[non_exhaustive]
+pub enum Nl80211UseMfp {
+    /// Management frame protection not used.
+    #[default]
+    No,
+    /// Management frame protection required (mandatory for WPA3).
+    Required,
+    /// Management frame protection used if the AP supports it.
+    Optional,
+    /// Any other / kernel-version-specific value.
+    Other(u32),
+}
+
+const NL80211_MFP_NO: u32 = 0;
+const NL80211_MFP_REQUIRED: u32 = 1;
+const NL80211_MFP_OPTIONAL: u32 = 2;
+
+impl From<u32> for Nl80211UseMfp {
+    fn from(d: u32) -> Self {
+        match d {
+            NL80211_MFP_NO => Self::No,
+            NL80211_MFP_REQUIRED => Self::Required,
+            NL80211_MFP_OPTIONAL => Self::Optional,
+            _ => Self::Other(d),
+        }
+    }
+}
+
+impl From<Nl80211UseMfp> for u32 {
+    fn from(v: Nl80211UseMfp) -> u32 {
+        match v {
+            Nl80211UseMfp::No => NL80211_MFP_NO,
+            Nl80211UseMfp::Required => NL80211_MFP_REQUIRED,
+            Nl80211UseMfp::Optional => NL80211_MFP_OPTIONAL,
+            Nl80211UseMfp::Other(d) => d,
+        }
+    }
+}
+
+bitflags::bitflags! {
+    /// Enabled WPA/RSN version(s), used with `NL80211_CMD_CONNECT`.
+    #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+    pub struct Nl80211WpaVersions: u32 {
+        /// WPA version 1 (deprecated).
+        const WPA1 = 1 << 0;
+        /// WPA version 2 / RSN. WPA3-Personal (SAE) also uses RSN, so this
+        /// bit is what most drivers expect for a WPA3 connection.
+        const WPA2 = 1 << 1;
+        /// WPA version 3.
+        const WPA3 = 1 << 2;
+    }
+}
+
+/// External authentication action, used with `NL80211_CMD_EXTERNAL_AUTH`.
+///
+/// Mirrors the kernel `enum nl80211_external_auth_action`. The kernel sends
+/// [`Nl80211ExternalAuthAction::Start`] (or `Abort`) to userspace to drive an
+/// external SAE authentication.
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
+#[non_exhaustive]
+pub enum Nl80211ExternalAuthAction {
+    /// Start external authentication.
+    #[default]
+    Start,
+    /// Abort external authentication.
+    Abort,
+    /// Any other / kernel-version-specific value.
+    Other(u32),
+}
+
+const NL80211_EXTERNAL_AUTH_START: u32 = 0;
+const NL80211_EXTERNAL_AUTH_ABORT: u32 = 1;
+
+impl From<u32> for Nl80211ExternalAuthAction {
+    fn from(d: u32) -> Self {
+        match d {
+            NL80211_EXTERNAL_AUTH_START => Self::Start,
+            NL80211_EXTERNAL_AUTH_ABORT => Self::Abort,
+            _ => Self::Other(d),
+        }
+    }
+}
+
+impl From<Nl80211ExternalAuthAction> for u32 {
+    fn from(v: Nl80211ExternalAuthAction) -> u32 {
+        match v {
+            Nl80211ExternalAuthAction::Start => NL80211_EXTERNAL_AUTH_START,
+            Nl80211ExternalAuthAction::Abort => NL80211_EXTERNAL_AUTH_ABORT,
+            Nl80211ExternalAuthAction::Other(d) => d,
+        }
+    }
+}

--- a/src/element.rs
+++ b/src/element.rs
@@ -497,10 +497,13 @@ pub struct Nl80211ElementRsn {
 
 impl Nl80211ElementRsn {
     pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
-        if payload.len() != 2 && payload.len() < 8 {
+        // Per IEEE 802.11-2020 9.4.2.24.1 the RSNE contains up to and including
+        // the mandatory 2-octet Version field; every field after it is
+        // optional.
+        if payload.len() < 2 {
             return Err(format!(
                 "Invalid buffer length of Nl80211ElementRsn, \
-                expecting 2 or bigger than 7, but got {payload:?}"
+                expecting at least 2, but got {payload:?}"
             )
             .into());
         }
@@ -533,7 +536,7 @@ impl Nl80211ElementRsn {
         }
 
         for _ in 0..pairwise_cipher_count {
-            if offset + Nl80211CipherSuite::LENGTH >= payload.len() {
+            if offset + Nl80211CipherSuite::LENGTH > payload.len() {
                 return Ok(ret);
             }
             ret.pairwise_ciphers.push(Nl80211CipherSuite::parse(
@@ -627,14 +630,14 @@ impl Emitable for Nl80211ElementRsn {
             len += 2;
         }
 
-        if self.pmkids.is_empty() {
+        if self.pmkids.is_empty() && self.group_mgmt_cipher.is_none() {
             return len;
-        } else {
-            len += 2 + self.pmkids.len() * Nl80211Pmkid::LENGTH;
         }
-        if self.group_mgmt_cipher.is_none() {
-            return len;
-        } else {
+        // PMKID count is always present once a PMKID list and/or a group
+        // management cipher follows the RSN capabilities.
+        len += 2 + self.pmkids.len() * Nl80211Pmkid::LENGTH;
+
+        if self.group_mgmt_cipher.is_some() {
             len += Nl80211CipherSuite::LENGTH;
         }
 
@@ -674,7 +677,7 @@ impl Emitable for Nl80211ElementRsn {
             offset += 2;
         }
 
-        if !self.pmkids.is_empty() {
+        if !self.pmkids.is_empty() || self.group_mgmt_cipher.is_some() {
             write_u16_le(
                 &mut buffer[offset..offset + 2],
                 self.pmkids.len() as u16,
@@ -683,6 +686,9 @@ impl Emitable for Nl80211ElementRsn {
             for pmkid in self.pmkids.as_slice() {
                 pmkid.emit(&mut buffer[offset..]);
                 offset += Nl80211Pmkid::LENGTH;
+            }
+            if let Some(c) = self.group_mgmt_cipher {
+                write_u32_le(&mut buffer[offset..offset + 4], u32::from(c));
             }
         }
     }

--- a/src/frame_type.rs
+++ b/src/frame_type.rs
@@ -5,7 +5,9 @@ use netlink_packet_core::{
     NlasIterator, Parseable,
 };
 
-use crate::{bytes::write_u16, Nl80211InterfaceType};
+use crate::{
+    attr::NL80211_ATTR_FRAME_TYPE, bytes::write_u16, Nl80211InterfaceType,
+};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[non_exhaustive]
@@ -27,8 +29,6 @@ impl Nla for Nl80211IfaceFrameType {
         self.attributes.as_slice().emit(buffer)
     }
 }
-
-const NL80211_ATTR_FRAME_TYPE: u16 = 101;
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for Nl80211IfaceFrameType

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -7,9 +7,9 @@ use netlink_packet_core::NetlinkMessage;
 use netlink_packet_generic::GenlMessage;
 
 use crate::{
-    try_nl80211, Nl80211Error, Nl80211InterfaceHandle, Nl80211Message,
-    Nl80211ScanHandle, Nl80211StationHandle, Nl80211SurveyHandle,
-    Nl80211WiphyHandle,
+    try_nl80211, Nl80211ConnectionHandle, Nl80211Error, Nl80211InterfaceHandle,
+    Nl80211Message, Nl80211ScanHandle, Nl80211StationHandle,
+    Nl80211SurveyHandle, Nl80211WiphyHandle,
 };
 
 #[derive(Clone, Debug)]
@@ -40,6 +40,11 @@ impl Nl80211Handle {
     // equivalent to `iw dev DEVICE scan` command
     pub fn scan(&self) -> Nl80211ScanHandle {
         Nl80211ScanHandle::new(self.clone())
+    }
+
+    // equivalent to `iw dev DEVICE connect` / `disconnect` commands
+    pub fn connection(&self) -> Nl80211ConnectionHandle {
+        Nl80211ConnectionHandle::new(self.clone())
     }
 
     // equivalent to `iw DEVICE survey dump` command

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ mod attr;
 mod builder;
 mod channel;
 mod command;
+mod connect;
 mod connection;
 mod element;
 mod error;
@@ -38,6 +39,13 @@ pub use self::attr::Nl80211Attr;
 pub use self::builder::Nl80211AttrsBuilder;
 pub use self::channel::Nl80211ChannelWidth;
 pub use self::command::Nl80211Command;
+pub use self::connect::{
+    Nl80211AuthType, Nl80211Connect, Nl80211ConnectRequest,
+    Nl80211ConnectionHandle, Nl80211Disconnect, Nl80211DisconnectRequest,
+    Nl80211ExternalAuth, Nl80211ExternalAuthAction, Nl80211ExternalAuthRequest,
+    Nl80211Frame, Nl80211FrameRequest, Nl80211RegisterFrame,
+    Nl80211RegisterFrameRequest, Nl80211UseMfp, Nl80211WpaVersions,
+};
 #[cfg(feature = "tokio_socket")]
 pub use self::connection::new_connection;
 pub use self::connection::new_connection_with_socket;

--- a/src/mlo.rs
+++ b/src/mlo.rs
@@ -5,8 +5,9 @@ use netlink_packet_core::{
     NlasIterator, Parseable,
 };
 
+use crate::attr::NL80211_ATTR_MAC;
+
 const ETH_ALEN: usize = 6;
-const NL80211_ATTR_MAC: u16 = 6;
 const NL80211_ATTR_MLO_LINK_ID: u16 = 313;
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/src/tests/connect.rs
+++ b/src/tests/connect.rs
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: MIT
+
+// On-wire `NL80211_ATTR_*` bytes captured on the `nl0` netlink monitor while
+// associating to a WPA3-Personal AP (hostapd + mac80211_hwsim) driven by
+// wpa_supplicant. Each `raw` blob is a single netlink attribute (length, type,
+// value), padded to the netlink 4-byte alignment, taken from the
+// `NL80211_CMD_AUTHENTICATE` / `NL80211_CMD_ASSOCIATE` messages. They validate
+// our parsing and emitting against what the kernel and userspace exchange.
+
+use netlink_packet_core::{Emitable, NlaBuffer, Parseable};
+
+use crate::{
+    Nl80211AkmSuite, Nl80211Attr, Nl80211AuthType, Nl80211CipherSuite,
+    Nl80211Element, Nl80211ElementRsn, Nl80211Elements, Nl80211RsnCapbilities,
+    Nl80211UseMfp, Nl80211WpaVersions,
+};
+
+// NL80211_ATTR_AUTH_TYPE = NL80211_AUTHTYPE_SAE (from CMD_AUTHENTICATE).
+#[test]
+fn test_captured_auth_type_sae() {
+    let raw = vec![0x08, 0x00, 0x35, 0x00, 0x04, 0x00, 0x00, 0x00];
+    let expected = Nl80211Attr::AuthType(Nl80211AuthType::Sae);
+    assert_eq!(
+        expected,
+        Nl80211Attr::parse(&NlaBuffer::new_checked(&raw).unwrap()).unwrap()
+    );
+    let mut buf = vec![0; expected.buffer_len()];
+    expected.emit(&mut buf);
+    assert_eq!(buf, raw);
+}
+
+// NL80211_ATTR_WPA_VERSIONS = NL80211_WPA_VERSION_3.
+#[test]
+fn test_captured_wpa_versions() {
+    let raw = vec![0x08, 0x00, 0x4b, 0x00, 0x04, 0x00, 0x00, 0x00];
+    let expected = Nl80211Attr::WpaVersions(Nl80211WpaVersions::WPA3);
+    assert_eq!(
+        expected,
+        Nl80211Attr::parse(&NlaBuffer::new_checked(&raw).unwrap()).unwrap()
+    );
+    let mut buf = vec![0; expected.buffer_len()];
+    expected.emit(&mut buf);
+    assert_eq!(buf, raw);
+}
+
+// NL80211_ATTR_CIPHER_SUITES_PAIRWISE = 00-0f-ac:4 (CCMP-128).
+#[test]
+fn test_captured_ciphers_pairwise() {
+    let raw = vec![0x08, 0x00, 0x49, 0x00, 0x04, 0xac, 0x0f, 0x00];
+    let expected =
+        Nl80211Attr::CiphersPairwise(vec![Nl80211CipherSuite::Ccmp128]);
+    assert_eq!(
+        expected,
+        Nl80211Attr::parse(&NlaBuffer::new_checked(&raw).unwrap()).unwrap()
+    );
+    let mut buf = vec![0; expected.buffer_len()];
+    expected.emit(&mut buf);
+    assert_eq!(buf, raw);
+}
+
+// NL80211_ATTR_CIPHER_SUITE_GROUP = 00-0f-ac:4 (CCMP-128).
+#[test]
+fn test_captured_cipher_group() {
+    let raw = vec![0x08, 0x00, 0x4a, 0x00, 0x04, 0xac, 0x0f, 0x00];
+    let expected = Nl80211Attr::CipherGroup(Nl80211CipherSuite::Ccmp128);
+    assert_eq!(
+        expected,
+        Nl80211Attr::parse(&NlaBuffer::new_checked(&raw).unwrap()).unwrap()
+    );
+    let mut buf = vec![0; expected.buffer_len()];
+    expected.emit(&mut buf);
+    assert_eq!(buf, raw);
+}
+
+// NL80211_ATTR_AKM_SUITES = 00-0f-ac:8 (SAE).
+#[test]
+fn test_captured_akm_suites() {
+    let raw = vec![0x08, 0x00, 0x4c, 0x00, 0x08, 0xac, 0x0f, 0x00];
+    let expected = Nl80211Attr::AkmSuites(vec![Nl80211AkmSuite::Sae]);
+    assert_eq!(
+        expected,
+        Nl80211Attr::parse(&NlaBuffer::new_checked(&raw).unwrap()).unwrap()
+    );
+    let mut buf = vec![0; expected.buffer_len()];
+    expected.emit(&mut buf);
+    assert_eq!(buf, raw);
+}
+
+// NL80211_ATTR_USE_MFP = NL80211_MFP_REQUIRED.
+#[test]
+fn test_captured_use_mfp() {
+    let raw = vec![0x08, 0x00, 0x42, 0x00, 0x01, 0x00, 0x00, 0x00];
+    let expected = Nl80211Attr::UseMfp(Nl80211UseMfp::Required);
+    assert_eq!(
+        expected,
+        Nl80211Attr::parse(&NlaBuffer::new_checked(&raw).unwrap()).unwrap()
+    );
+    let mut buf = vec![0; expected.buffer_len()];
+    expected.emit(&mut buf);
+    assert_eq!(buf, raw);
+}
+
+// NL80211_ATTR_SOCKET_OWNER (flag).
+#[test]
+fn test_captured_socket_owner() {
+    let raw = vec![0x04, 0x00, 0xcc, 0x00];
+    let expected = Nl80211Attr::SocketOwner;
+    assert_eq!(
+        expected,
+        Nl80211Attr::parse(&NlaBuffer::new_checked(&raw).unwrap()).unwrap()
+    );
+    let mut buf = vec![0; expected.buffer_len()];
+    expected.emit(&mut buf);
+    assert_eq!(buf, raw);
+}
+
+// NL80211_ATTR_CONTROL_PORT_OVER_NL80211 (flag) from the association request.
+#[test]
+fn test_captured_control_port_over_nl80211() {
+    let raw = vec![0x04, 0x00, 0x08, 0x01];
+    let expected = Nl80211Attr::ControlPortOverNl80211;
+    assert_eq!(
+        expected,
+        Nl80211Attr::parse(&NlaBuffer::new_checked(&raw).unwrap()).unwrap()
+    );
+    let mut buf = vec![0; expected.buffer_len()];
+    expected.emit(&mut buf);
+    assert_eq!(buf, raw);
+}
+
+// NL80211_ATTR_STATUS_CODE = 0 (success) from the CMD_CONNECT event.
+#[test]
+fn test_captured_status_code() {
+    let raw = vec![0x06, 0x00, 0x48, 0x00, 0x00, 0x00, 0x00, 0x00];
+    let expected = Nl80211Attr::StatusCode(0);
+    assert_eq!(
+        expected,
+        Nl80211Attr::parse(&NlaBuffer::new_checked(&raw).unwrap()).unwrap()
+    );
+    let mut buf = vec![0; expected.buffer_len()];
+    expected.emit(&mut buf);
+    assert_eq!(buf, raw);
+}
+
+// NL80211_ATTR_IE value from the association request: the RSN information
+// element (plus extended capabilities and supported operating classes) that
+// wpa_supplicant inserts. Parsed with `Nl80211Elements::parse()`.
+#[test]
+fn test_captured_ie_rsn() {
+    let raw = vec![
+        0x30, 0x1a, 0x01, 0x00, 0x00, 0x0f, 0xac, 0x04, 0x01, 0x00, 0x00, 0x0f,
+        0xac, 0x04, 0x01, 0x00, 0x00, 0x0f, 0xac, 0x08, 0xc0, 0x00, 0x00, 0x00,
+        0x00, 0x0f, 0xac, 0x06, 0x7f, 0x0a, 0x04, 0x00, 0x4a, 0x02, 0x01, 0x40,
+        0x00, 0x40, 0x00, 0x01, 0x3b, 0x17, 0x51, 0x51, 0x52, 0x53, 0x54, 0x73,
+        0x74, 0x75, 0x76, 0x77, 0x78, 0x79, 0x7a, 0x7b, 0x7c, 0x7d, 0x7e, 0x7f,
+        0x80, 0x81, 0x00, 0x82, 0x80,
+    ];
+    let expected = Nl80211Elements(vec![
+        Nl80211Element::Rsn(Nl80211ElementRsn {
+            version: 1,
+            group_cipher: Some(Nl80211CipherSuite::Ccmp128),
+            pairwise_ciphers: vec![Nl80211CipherSuite::Ccmp128],
+            akm_suits: vec![Nl80211AkmSuite::Sae],
+            rsn_capbilities: Some(
+                Nl80211RsnCapbilities::Mfpr | Nl80211RsnCapbilities::Mfpc,
+            ),
+            pmkids: vec![],
+            group_mgmt_cipher: Some(Nl80211CipherSuite::BipCmac128),
+        }),
+        Nl80211Element::Other(127, vec![4, 0, 74, 2, 1, 64, 0, 64, 0, 1]),
+        Nl80211Element::Other(
+            59,
+            vec![
+                81, 81, 82, 83, 84, 115, 116, 117, 118, 119, 120, 121, 122,
+                123, 124, 125, 126, 127, 128, 129, 0, 130, 128,
+            ],
+        ),
+    ]);
+    assert_eq!(expected, Nl80211Elements::parse(&raw).unwrap());
+    let mut buf = vec![0; expected.buffer_len()];
+    expected.emit(&mut buf);
+    assert_eq!(buf, raw);
+}
+
+// NL80211_ATTR_FRAME: the (re)association response management frame
+// delivered to userspace in the CMD_ASSOCIATE event.
+#[test]
+fn test_captured_frame() {
+    let raw = vec![
+        0x3c, 0x00, 0x33, 0x00, 0x10, 0x00, 0x3a, 0x01, 0x02, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x02, 0x00, 0x00, 0x00,
+        0x01, 0x00, 0xb0, 0x01, 0x11, 0x04, 0x00, 0x00, 0x01, 0xc0, 0x01, 0x08,
+        0x82, 0x84, 0x8b, 0x96, 0x0c, 0x12, 0x18, 0x24, 0x32, 0x04, 0x30, 0x48,
+        0x60, 0x6c, 0x7f, 0x08, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40,
+    ];
+    let expected = Nl80211Attr::Frame(vec![
+        0x10, 0x00, 0x3a, 0x01, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00,
+        0x00, 0x00, 0x01, 0x00, 0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0xb0, 0x01,
+        0x11, 0x04, 0x00, 0x00, 0x01, 0xc0, 0x01, 0x08, 0x82, 0x84, 0x8b, 0x96,
+        0x0c, 0x12, 0x18, 0x24, 0x32, 0x04, 0x30, 0x48, 0x60, 0x6c, 0x7f, 0x08,
+        0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40,
+    ]);
+    assert_eq!(
+        expected,
+        Nl80211Attr::parse(&NlaBuffer::new_checked(&raw).unwrap()).unwrap()
+    );
+    let mut buf = vec![0; expected.buffer_len()];
+    expected.emit(&mut buf);
+    assert_eq!(buf, raw);
+}

--- a/src/tests/disconnect.rs
+++ b/src/tests/disconnect.rs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+
+// On-wire `NL80211_ATTR_*` bytes captured on the `nl0` netlink monitor while a
+// WPA3-Personal connection (hostapd + mac80211_hwsim, driven by
+// wpa_supplicant) was torn down. The blobs are taken from the
+// `NL80211_CMD_DEAUTHENTICATE` request/event and the `NL80211_CMD_DISCONNECT`
+// event. Each `raw` is a single netlink attribute (length, type, value), padded
+// to the netlink 4-byte alignment, with the unrelated message/genl headers
+// stripped. They validate our parsing and emitting against what the kernel and
+// userspace exchange.
+
+use netlink_packet_core::{Emitable, NlaBuffer, Parseable};
+
+use crate::Nl80211Attr;
+
+// NL80211_ATTR_REASON_CODE = 3 ("Deauthenticated because sending STA is
+// leaving the BSS"). These exact bytes appear in both the
+// CMD_DEAUTHENTICATE request and the CMD_DISCONNECT event.
+#[test]
+fn test_captured_reason_code() {
+    let raw = vec![0x06, 0x00, 0x36, 0x00, 0x03, 0x00, 0x00, 0x00];
+    let expected = Nl80211Attr::ReasonCode(3);
+    assert_eq!(
+        expected,
+        Nl80211Attr::parse(&NlaBuffer::new_checked(&raw).unwrap()).unwrap()
+    );
+    let mut buf = vec![0; expected.buffer_len()];
+    expected.emit(&mut buf);
+    assert_eq!(buf, raw);
+}
+
+// NL80211_ATTR_MAC: the BSSID the STA deauthenticates from, taken from the
+// CMD_DEAUTHENTICATE request (02:00:00:00:01:00).
+#[test]
+fn test_captured_deauthenticate_mac() {
+    let raw = vec![
+        0x0a, 0x00, 0x06, 0x00, 0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+    ];
+    let expected = Nl80211Attr::Mac([0x02, 0x00, 0x00, 0x00, 0x01, 0x00]);
+    assert_eq!(
+        expected,
+        Nl80211Attr::parse(&NlaBuffer::new_checked(&raw).unwrap()).unwrap()
+    );
+    let mut buf = vec![0; expected.buffer_len()];
+    expected.emit(&mut buf);
+    assert_eq!(buf, raw);
+}
+
+// NL80211_ATTR_FRAME: the Deauthentication management frame delivered to
+// userspace in the CMD_DEAUTHENTICATE event. Value length 26 bytes, so the
+// attribute is padded to 32.
+#[test]
+fn test_captured_deauthenticate_frame() {
+    let raw = vec![
+        0x1e, 0x00, 0x33, 0x00, 0xc0, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
+        0x01, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
+        0x01, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00,
+    ];
+    let expected = Nl80211Attr::Frame(vec![
+        0xc0, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x02, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+        0x03, 0x00,
+    ]);
+    assert_eq!(
+        expected,
+        Nl80211Attr::parse(&NlaBuffer::new_checked(&raw).unwrap()).unwrap()
+    );
+    let mut buf = vec![0; expected.buffer_len()];
+    expected.emit(&mut buf);
+    assert_eq!(buf, raw);
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,3 +1,6 @@
 // SPDX-License-Identifier: MIT
 
+mod connect;
+mod disconnect;
+mod register_frame;
 mod scan;

--- a/src/tests/register_frame.rs
+++ b/src/tests/register_frame.rs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+
+// On-wire `NL80211_ATTR_*` bytes captured on the `nl0` netlink monitor on
+// mac80211_hwsim. `NL80211_ATTR_FRAME_TYPE` and `NL80211_ATTR_FRAME_MATCH`
+// were taken from the `NL80211_CMD_REGISTER_FRAME` messages wpa_supplicant
+// emits when it initialises on an interface to register for management frames.
+// `NL80211_ATTR_PRIVACY` was taken from a `NL80211_CMD_CONNECT` issued with
+// `iw dev <ifname> connect <ssid> <bssid> key 0:<wepkey>`. Each `raw` blob is a
+// single netlink attribute (length, type, value) padded to the netlink 4-byte
+// alignment.
+
+use netlink_packet_core::{Emitable, NlaBuffer, Parseable};
+
+use crate::Nl80211Attr;
+
+// NL80211_ATTR_FRAME_TYPE = 0x00d0 (IEEE 802.11 management Action frame), from
+// CMD_REGISTER_FRAME.
+#[test]
+fn test_captured_frame_type() {
+    let raw = vec![0x06, 0x00, 0x65, 0x00, 0xd0, 0x00, 0x00, 0x00];
+    let expected = Nl80211Attr::FrameType(0x00d0);
+    assert_eq!(
+        expected,
+        Nl80211Attr::parse(&NlaBuffer::new_checked(&raw).unwrap()).unwrap()
+    );
+    let mut buf = vec![0; expected.buffer_len()];
+    expected.emit(&mut buf);
+    assert_eq!(buf, raw);
+}
+
+// NL80211_ATTR_FRAME_MATCH: the management frame body prefix to match, from
+// CMD_REGISTER_FRAME.
+#[test]
+fn test_captured_frame_match() {
+    let raw = vec![0x06, 0x00, 0x5b, 0x00, 0x01, 0x04, 0x00, 0x00];
+    let expected = Nl80211Attr::FrameMatch(vec![0x01, 0x04]);
+    assert_eq!(
+        expected,
+        Nl80211Attr::parse(&NlaBuffer::new_checked(&raw).unwrap()).unwrap()
+    );
+    let mut buf = vec![0; expected.buffer_len()];
+    expected.emit(&mut buf);
+    assert_eq!(buf, raw);
+}
+
+// NL80211_ATTR_PRIVACY: flag indicating the BSS uses privacy (protected
+// frames), from CMD_CONNECT.
+#[test]
+fn test_captured_privacy() {
+    let raw = vec![0x04, 0x00, 0x46, 0x00];
+    let expected = Nl80211Attr::Privacy;
+    assert_eq!(
+        expected,
+        Nl80211Attr::parse(&NlaBuffer::new_checked(&raw).unwrap()).unwrap()
+    );
+    let mut buf = vec![0; expected.buffer_len()];
+    expected.emit(&mut buf);
+    assert_eq!(buf, raw);
+}


### PR DESCRIPTION
Added the following netlink attributes:
 * NL80211_ATTR_ACK
 * NL80211_ATTR_AKM_SUITES
 * NL80211_ATTR_AUTH_TYPE
 * NL80211_ATTR_BSSID
 * NL80211_ATTR_CIPHER_SUITE_GROUP
 * NL80211_ATTR_CIPHER_SUITES_PAIRWISE
 * NL80211_ATTR_CONTROL_PORT_OVER_NL80211
 * NL80211_ATTR_COOKIE
 * NL80211_ATTR_EXTERNAL_AUTH_ACTION
 * NL80211_ATTR_EXTERNAL_AUTH_SUPPORT
 * NL80211_ATTR_FRAME
 * NL80211_ATTR_FRAME_MATCH
 * NL80211_ATTR_FRAME_TYPE
 * NL80211_ATTR_IE
 * NL80211_ATTR_PRIVACY
 * NL80211_ATTR_REASON_CODE
 * NL80211_ATTR_SOCKET_OWNER
 * NL80211_ATTR_STATUS_CODE
 * NL80211_ATTR_USE_MFP
 * NL80211_ATTR_WPA_VERSIONS

Unit test cases included with real capture netlink packet.