### PR TITLE
Fix incorrect usage on DefaultNla

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -1124,7 +1124,7 @@ impl Nla for Nl80211Attr {
             Self::Ie(v) | Self::Frame(v) | Self::FrameMatch(v) => {
                 buffer[..v.len()].copy_from_slice(v)
             }
-            Self::Other(attr) => attr.emit(buffer),
+            Self::Other(attr) => attr.emit_value(buffer),
         }
     }
 }


### PR DESCRIPTION
When emiting, we should use `emit_value()` as other rust-netlink attribute
does.

Resolves: https://github.com/rust-netlink/wl-nl80211/issues/59