### PR TITLE
Fix NL80211_ATTR_SSID to be binary, not NUL-terminated

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -746,7 +746,11 @@ impl Nla for Nl80211Attr {
             | Self::VendorId(_)
             | Self::VendorSubcmd(_) => 4,
             Self::Wdev(_) => 8,
-            Self::IfName(s) | Self::Ssid(s) | Self::WiphyName(s) => s.len() + 1,
+            Self::IfName(s) | Self::WiphyName(s) => s.len() + 1,
+            // NL80211_ATTR_SSID is a binary attribute (0..32 octets) and must
+            // not be NUL-terminated, otherwise the kernel's SSID matching
+            // (e.g. cfg80211_get_bss) fails.
+            Self::Ssid(s) => s.len(),
             Self::Mac(_) | Self::MacMask(_) => ETH_ALEN,
             Self::MacAddrs(s) => {
                 MacAddressNlas::from(s).as_slice().buffer_len()
@@ -1005,9 +1009,13 @@ impl Nla for Nl80211Attr {
             Self::MacAddrs(s) => {
                 MacAddressNlas::from(s).as_slice().emit(buffer)
             }
-            Self::IfName(s) | Self::Ssid(s) | Self::WiphyName(s) => {
+            Self::IfName(s) | Self::WiphyName(s) => {
                 buffer[..s.len()].copy_from_slice(s.as_bytes());
                 buffer[s.len()] = 0;
+            }
+            // NL80211_ATTR_SSID: binary, not NUL-terminated.
+            Self::Ssid(s) => {
+                buffer[..s.len()].copy_from_slice(s.as_bytes());
             }
             Self::Use4Addr(d) => buffer[0] = *d as u8,
             Self::SupportIbssRsn


### PR DESCRIPTION
Nl80211Attr::Ssid was grouped with the NUL-terminated string attributes
IfName/WiphyName, so it was emitted with a trailing NUL and a length of
s.len() + 1.

NL80211_ATTR_SSID is a binary attribute (0..32 octets), not a NUL-string
(see include/uapi/linux/nl80211.h: "NL80211_ATTR_SSID: SSID (binary
attribute, 0..32 octets)"). The kernel reads the SSID length directly from
the attribute length: in net/wireless/nl80211.c nl80211_authenticate() and
nl80211_associate() do

    ssid_len = nla_len(info->attrs[NL80211_ATTR_SSID]);

and pass it to cfg80211_get_bss() (net/wireless/scan.c), which matches the
BSS by comparing exactly ssid_len SSID octets. A trailing NUL makes
ssid_len one byte too long and includes the 0x00 byte in the comparison, so
the lookup fails and the command returns -ENOENT.

Emit Ssid as raw bytes with length s.len() so AUTHENTICATE/ASSOCIATE (and
any other SSID matching) work correctly.