### PR TITLE
Add support for NL80211_ATTR_REKEY_DATA

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -46,10 +46,10 @@ use crate::{
     Nl80211HtCapabilityMask, Nl80211HtWiphyChannelType, Nl80211IfMode,
     Nl80211IfTypeExtCapa, Nl80211IfTypeExtCapas, Nl80211IfaceComb,
     Nl80211IfaceFrameType, Nl80211InterfaceType, Nl80211InterfaceTypes,
-    Nl80211KeyAttr, Nl80211MloLink, Nl80211ScanFlags, Nl80211SchedScanMatch,
-    Nl80211SchedScanPlan, Nl80211StationInfo, Nl80211SurveyInfo,
-    Nl80211TransmitQueueStat, Nl80211UseMfp, Nl80211VhtCapability,
-    Nl80211WowlanTriggersSupport, Nl80211WpaVersions,
+    Nl80211KeyAttr, Nl80211MloLink, Nl80211RekeyData, Nl80211ScanFlags,
+    Nl80211SchedScanMatch, Nl80211SchedScanPlan, Nl80211StationInfo,
+    Nl80211SurveyInfo, Nl80211TransmitQueueStat, Nl80211UseMfp,
+    Nl80211VhtCapability, Nl80211WowlanTriggersSupport, Nl80211WpaVersions,
 };
 
 const ETH_ALEN: usize = 6;
@@ -307,7 +307,7 @@ const NL80211_ATTR_WOWLAN_TRIGGERS_SUPPORTED: u16 = 118;
 const NL80211_ATTR_SCHED_SCAN_INTERVAL: u16 = 119;
 const NL80211_ATTR_INTERFACE_COMBINATIONS: u16 = 120;
 const NL80211_ATTR_SOFTWARE_IFTYPES: u16 = 121;
-// const NL80211_ATTR_REKEY_DATA:u16 = 122;
+const NL80211_ATTR_REKEY_DATA: u16 = 122;
 const NL80211_ATTR_MAX_NUM_SCHED_SCAN_SSIDS: u16 = 123;
 const NL80211_ATTR_MAX_SCHED_SCAN_IE_LEN: u16 = 124;
 // const NL80211_ATTR_SCAN_SUPP_RATES:u16 = 125;
@@ -689,6 +689,10 @@ pub enum Nl80211Attr {
     /// [`Nl80211KeyAttr`] sub-attributes: the key material, index, cipher,
     /// sequence/RSC, type, etc.).
     Key(Vec<Nl80211KeyAttr>),
+    /// GTK rekey offload parameters for `NL80211_CMD_SET_REKEY_OFFLOAD`,
+    /// carried as the nested `NL80211_ATTR_REKEY_DATA` attribute (a list of
+    /// [`Nl80211RekeyData`] sub-attributes: KEK, KCK, replay counter, AKM).
+    RekeyData(Vec<Nl80211RekeyData>),
     /// IEEE 802.11 frame type/subtype to register for / that a frame belongs
     /// to (the 16-bit frame control type+subtype field).
     FrameType(u16),
@@ -849,6 +853,7 @@ impl Nla for Nl80211Attr {
             Self::Ie(v) | Self::Frame(v) | Self::FrameMatch(v) => v.len(),
             Self::AuthData(v) => v.len(),
             Self::Key(nlas) => nlas.as_slice().buffer_len(),
+            Self::RekeyData(nlas) => nlas.as_slice().buffer_len(),
             Self::Other(attr) => attr.value_len(),
             Self::VendorData(d) => d.len(),
         }
@@ -977,6 +982,7 @@ impl Nla for Nl80211Attr {
             Self::FrameMatch(_) => NL80211_ATTR_FRAME_MATCH,
             Self::AuthData(_) => NL80211_ATTR_AUTH_DATA,
             Self::Key(_) => NL80211_ATTR_KEY,
+            Self::RekeyData(_) => NL80211_ATTR_REKEY_DATA,
             Self::FrameType(_) => NL80211_ATTR_FRAME_TYPE,
             Self::Cookie(_) => NL80211_ATTR_COOKIE,
             Self::Ack => NL80211_ATTR_ACK,
@@ -1153,6 +1159,7 @@ impl Nla for Nl80211Attr {
             }
             Self::AuthData(v) => buffer[..v.len()].copy_from_slice(v),
             Self::Key(nlas) => nlas.as_slice().emit(buffer),
+            Self::RekeyData(nlas) => nlas.as_slice().emit(buffer),
             Self::Other(attr) => attr.emit_value(buffer),
         }
     }
@@ -1787,6 +1794,20 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nl80211Attr {
                     );
                 }
                 Self::Key(nlas)
+            }
+            NL80211_ATTR_REKEY_DATA => {
+                let err_msg = format!(
+                    "Invalid NL80211_ATTR_REKEY_DATA value {payload:?}"
+                );
+                let mut nlas = Vec::new();
+                for nla in NlasIterator::new(payload) {
+                    let nla = &nla.context(err_msg.clone())?;
+                    nlas.push(
+                        Nl80211RekeyData::parse(nla)
+                            .context(err_msg.clone())?,
+                    );
+                }
+                Self::RekeyData(nlas)
             }
             NL80211_ATTR_FRAME_TYPE => {
                 let err_msg = format!(

--- a/src/element.rs
+++ b/src/element.rs
@@ -826,6 +826,7 @@ const AKM_FILS_SHA256_AES_SIV256_OR_1X: u32 = IEEE_80211_OUI | 14 << 24;
 const AKM_FILS_SHA384_AES_SIV512_OR_1X: u32 = IEEE_80211_OUI | 15 << 24;
 const AKM_FT_FILS_SHA256_AES_SIV256_OR_1X: u32 = IEEE_80211_OUI | 16 << 24;
 const AKM_FT_FILS_SHA384_AES_SIV512_OR_1X: u32 = IEEE_80211_OUI | 17 << 24;
+const AKM_OWE: u32 = IEEE_80211_OUI | 18 << 24;
 const AKM_FT_PSK_SHA384: u32 = IEEE_80211_OUI | 19 << 24;
 const AKM_PSK_SHA384: u32 = IEEE_80211_OUI | 20 << 24;
 const AKM_SAE_GROUP_HASH: u32 = IEEE_80211_OUI | 24 << 24;
@@ -852,6 +853,7 @@ pub enum Nl80211AkmSuite {
     FilsSha384AesSiv512OrIeee8021x,
     FtFilsSha256AesSiv256OrIeee8021x,
     FtFilsSha384AesSiv512OrIeee8021x,
+    Owe,
     FtPskSha384,
     PskSha384,
     // Defined in WPA 3 as 00-0F-AC:24
@@ -889,6 +891,7 @@ impl From<u32> for Nl80211AkmSuite {
             AKM_FT_FILS_SHA384_AES_SIV512_OR_1X => {
                 Self::FtFilsSha384AesSiv512OrIeee8021x
             }
+            AKM_OWE => Self::Owe,
             AKM_FT_PSK_SHA384 => Self::FtPskSha384,
             AKM_PSK_SHA384 => Self::PskSha384,
             AKM_SAE_GROUP_HASH => Self::SaeGroupDependentHash,
@@ -926,6 +929,7 @@ impl From<Nl80211AkmSuite> for u32 {
             Nl80211AkmSuite::FtFilsSha384AesSiv512OrIeee8021x => {
                 AKM_FT_FILS_SHA384_AES_SIV512_OR_1X
             }
+            Nl80211AkmSuite::Owe => AKM_OWE,
             Nl80211AkmSuite::FtPskSha384 => AKM_FT_PSK_SHA384,
             Nl80211AkmSuite::PskSha384 => AKM_PSK_SHA384,
             Nl80211AkmSuite::SaeGroupDependentHash => AKM_SAE_GROUP_HASH,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ mod key;
 mod macros;
 mod message;
 mod mlo;
+mod rekey;
 mod scan;
 mod station;
 mod stats;
@@ -74,6 +75,7 @@ pub use self::iface::{
 pub use self::key::{Nl80211KeyAttr, Nl80211KeyDefaultType, Nl80211KeyType};
 pub use self::message::Nl80211Message;
 pub use self::mlo::Nl80211MloLink;
+pub use self::rekey::Nl80211RekeyData;
 pub use self::scan::{
     Nl80211BssCapabilities, Nl80211BssInfo, Nl80211BssUseFor, Nl80211Scan,
     Nl80211ScanFlags, Nl80211ScanGetRequest, Nl80211ScanHandle,

--- a/src/rekey.rs
+++ b/src/rekey.rs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+
+use netlink_packet_core::{
+    emit_u32, parse_u32, DecodeError, DefaultNla, ErrorContext, Nla, NlaBuffer,
+    Parseable,
+};
+
+const NL80211_REKEY_DATA_KEK: u16 = 1;
+const NL80211_REKEY_DATA_KCK: u16 = 2;
+const NL80211_REKEY_DATA_REPLAY_CTR: u16 = 3;
+const NL80211_REKEY_DATA_AKM: u16 = 4;
+
+/// Sub-attributes within the nested `NL80211_ATTR_REKEY_DATA` attribute,
+/// used with `NL80211_CMD_SET_REKEY_OFFLOAD` to hand GTK rekey material
+/// to the driver/firmware.
+///
+/// Mirrors the kernel `enum nl80211_rekey_data`.
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
+pub enum Nl80211RekeyData {
+    /// Key Encryption Key (16–32 bytes depending on AKM).
+    Kek(Vec<u8>),
+    /// Key Confirmation Key (16–24 bytes depending on AKM).
+    Kck(Vec<u8>),
+    /// Replay counter (8 bytes).
+    ReplayCtr(Vec<u8>),
+    /// AKM suite selector (kernel-native encoding, e.g. `0x000FAC08`
+    /// for SAE).
+    Akm(u32),
+    /// Any other / kernel-version-specific sub-attribute.
+    Other(DefaultNla),
+}
+
+impl Nla for Nl80211RekeyData {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::Kek(v) | Self::Kck(v) | Self::ReplayCtr(v) => v.len(),
+            Self::Akm(_) => 4,
+            Self::Other(attr) => attr.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::Kek(_) => NL80211_REKEY_DATA_KEK,
+            Self::Kck(_) => NL80211_REKEY_DATA_KCK,
+            Self::ReplayCtr(_) => NL80211_REKEY_DATA_REPLAY_CTR,
+            Self::Akm(_) => NL80211_REKEY_DATA_AKM,
+            Self::Other(attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::Kek(v) | Self::Kck(v) | Self::ReplayCtr(v) => {
+                buffer[..v.len()].copy_from_slice(v)
+            }
+            Self::Akm(d) => emit_u32(buffer, *d).unwrap(),
+            Self::Other(attr) => attr.emit_value(buffer),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
+    for Nl80211RekeyData
+{
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            NL80211_REKEY_DATA_KEK => Self::Kek(payload.to_vec()),
+            NL80211_REKEY_DATA_KCK => Self::Kck(payload.to_vec()),
+            NL80211_REKEY_DATA_REPLAY_CTR => Self::ReplayCtr(payload.to_vec()),
+            NL80211_REKEY_DATA_AKM => {
+                let err_msg =
+                    format!("Invalid NL80211_REKEY_DATA_AKM {payload:?}");
+                Self::Akm(parse_u32(payload).context(err_msg)?)
+            }
+            _ => Self::Other(DefaultNla::parse(buf)?),
+        })
+    }
+}


### PR DESCRIPTION
Add `Nl80211RekeyData` enum with `Kek`, `Kck`, `ReplayCtr` and `Akm`
variants, and the `Nl80211Attr::RekeyData` variant carrying them as a
nested attribute.  This enables building and parsing
`NL80211_CMD_SET_REKEY_OFFLOAD` messages for GTK rekey offload to
driver/firmware.

Mirrors the kernel `enum nl80211_rekey_data` from
include/uapi/linux/nl80211.h.