### PR TITLE
Add NEW_KEY and SET_REKEY_OFFLOAD request builders

### DIFF
--- a/src/connect/handle.rs
+++ b/src/connect/handle.rs
@@ -4,7 +4,7 @@ use crate::{
     Nl80211AssociateRequest, Nl80211Attr, Nl80211AuthenticateRequest,
     Nl80211ConnectRequest, Nl80211DisconnectRequest,
     Nl80211ExternalAuthRequest, Nl80211FrameRequest, Nl80211Handle,
-    Nl80211RegisterFrameRequest,
+    Nl80211KeyRequest, Nl80211RegisterFrameRequest, Nl80211RekeyOffloadRequest,
 };
 
 /// A handle to send connection management commands (`NL80211_CMD_CONNECT` and
@@ -106,5 +106,31 @@ impl Nl80211ConnectionHandle {
         attributes: Vec<Nl80211Attr>,
     ) -> Nl80211RegisterFrameRequest {
         Nl80211RegisterFrameRequest::new(self.0.clone(), attributes)
+    }
+
+    /// Install a key (`NL80211_CMD_NEW_KEY`), used during the 4-way
+    /// handshake to install the PTK / GTK.
+    ///
+    /// The `attributes` are normally produced by
+    /// [`crate::Nl80211Key`], e.g. [`crate::Nl80211Key::new_ptk`] or
+    /// [`crate::Nl80211Key::new_gtk`].
+    pub fn new_key(
+        &mut self,
+        attributes: Vec<Nl80211Attr>,
+    ) -> Nl80211KeyRequest {
+        Nl80211KeyRequest::new(self.0.clone(), attributes)
+    }
+
+    /// Hand GTK rekey material to the driver/firmware
+    /// (`NL80211_CMD_SET_REKEY_OFFLOAD`), so the device can keep receiving
+    /// while the host is suspended (WoWLAN).
+    ///
+    /// The `attributes` are normally produced by
+    /// [`crate::Nl80211RekeyOffload`].
+    pub fn set_rekey_offload(
+        &mut self,
+        attributes: Vec<Nl80211Attr>,
+    ) -> Nl80211RekeyOffloadRequest {
+        Nl80211RekeyOffloadRequest::new(self.0.clone(), attributes)
     }
 }

--- a/src/key_request.rs
+++ b/src/key_request.rs
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: MIT
+
+use futures::TryStream;
+use netlink_packet_core::{NLM_F_ACK, NLM_F_REQUEST};
+use netlink_packet_generic::GenlMessage;
+
+use crate::{
+    nl80211_execute, Nl80211Attr, Nl80211CipherSuite, Nl80211Command,
+    Nl80211Error, Nl80211Handle, Nl80211KeyAttr, Nl80211KeyDefaultType,
+    Nl80211KeyType, Nl80211Message,
+};
+
+/// Helper to build the attribute list for a `NL80211_CMD_NEW_KEY` request
+/// (key installation).
+///
+/// For station mode `NL80211_CMD_NEW_KEY` alone is enough: the kernel
+/// selects the GTK for RX by the Key ID subfield in the CCMP header
+/// (802.11-2020 §12.5.3.2), so no `NL80211_CMD_SET_KEY` is required.
+#[derive(Debug)]
+pub struct Nl80211Key;
+
+impl Nl80211Key {
+    /// Start building a `NL80211_CMD_NEW_KEY` request for `if_index`.
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(if_index: u32) -> Nl80211KeyRequestBuilder {
+        Nl80211KeyRequestBuilder {
+            if_index,
+            mac: None,
+            key_data: Vec::new(),
+            key_index: 0,
+            cipher: Nl80211CipherSuite::Ccmp128,
+            seq: None,
+            key_type: None,
+            default_types: Vec::new(),
+        }
+    }
+
+    /// Convenience for installing the pairwise (unicast) key: CCMP-128 at
+    /// key index 0 for `peer_mac`.
+    pub fn new_ptk(
+        if_index: u32,
+        peer_mac: [u8; 6],
+        key_data: Vec<u8>,
+    ) -> Nl80211KeyRequestBuilder {
+        Self::new(if_index)
+            .mac(peer_mac)
+            .key_data(key_data)
+            .key_type(Nl80211KeyType::Pairwise)
+    }
+
+    /// Convenience for installing a group (multicast) key: CCMP-128 at
+    /// `key_index`, marked as the default multicast key via
+    /// `NL80211_KEY_DEFAULT_TYPES` (`NL80211_KEY_DEFAULT_TYPE_MULTICAST`).
+    pub fn new_gtk(
+        if_index: u32,
+        key_data: Vec<u8>,
+        key_index: u8,
+    ) -> Nl80211KeyRequestBuilder {
+        Self::new(if_index)
+            .key_data(key_data)
+            .key_index(key_index)
+            .key_type(Nl80211KeyType::Group)
+            .default_types(vec![Nl80211KeyDefaultType::Multicast])
+    }
+}
+
+/// Builder for the attributes of a `NL80211_CMD_NEW_KEY` request.
+#[derive(Debug)]
+pub struct Nl80211KeyRequestBuilder {
+    if_index: u32,
+    mac: Option<[u8; 6]>,
+    key_data: Vec<u8>,
+    key_index: u8,
+    cipher: Nl80211CipherSuite,
+    seq: Option<Vec<u8>>,
+    key_type: Option<Nl80211KeyType>,
+    default_types: Vec<Nl80211KeyDefaultType>,
+}
+
+impl Nl80211KeyRequestBuilder {
+    /// The peer the pairwise key belongs to; omit for group keys.
+    pub fn mac(mut self, mac: [u8; 6]) -> Self {
+        self.mac = Some(mac);
+        self
+    }
+
+    /// Key material (e.g. the 16-byte CCMP temporal key).
+    pub fn key_data(mut self, data: Vec<u8>) -> Self {
+        self.key_data = data;
+        self
+    }
+
+    /// Key index: 0 for the pairwise key, 1-3 for group keys.
+    pub fn key_index(mut self, idx: u8) -> Self {
+        self.key_index = idx;
+        self
+    }
+
+    /// Cipher suite, e.g. [`Nl80211CipherSuite::Ccmp128`].
+    pub fn cipher(mut self, cipher: Nl80211CipherSuite) -> Self {
+        self.cipher = cipher;
+        self
+    }
+
+    /// Receive sequence counter (RSC) / packet number.
+    pub fn seq(mut self, seq: Vec<u8>) -> Self {
+        self.seq = Some(seq);
+        self
+    }
+
+    /// Key type (pairwise / group / PMK).
+    pub fn key_type(mut self, key_type: Nl80211KeyType) -> Self {
+        self.key_type = Some(key_type);
+        self
+    }
+
+    /// Traffic types this key is the default for.
+    pub fn default_types(
+        mut self,
+        default_types: Vec<Nl80211KeyDefaultType>,
+    ) -> Self {
+        self.default_types = default_types;
+        self
+    }
+
+    /// Build the attribute list for a `NL80211_CMD_NEW_KEY` request.
+    pub fn build(self) -> Vec<Nl80211Attr> {
+        // `Nl80211CipherSuite` stores the 802.11 element byte-order; the
+        // netlink `NL80211_KEY_CIPHER` attribute expects the kernel's u32
+        // (OUI in the high bytes), so swap — see the `CiphersPairwise` emit
+        // in `attr.rs`.
+        let cipher = u32::from(self.cipher).swap_bytes();
+        let mut key = vec![
+            Nl80211KeyAttr::Data(self.key_data),
+            Nl80211KeyAttr::Cipher(cipher),
+        ];
+        if let Some(seq) = self.seq {
+            key.push(Nl80211KeyAttr::Seq(seq));
+        }
+        key.push(Nl80211KeyAttr::Idx(self.key_index));
+        if let Some(key_type) = self.key_type {
+            key.push(Nl80211KeyAttr::Type(key_type));
+        }
+        if !self.default_types.is_empty() {
+            key.push(Nl80211KeyAttr::DefaultTypes(self.default_types));
+        }
+        let mut attributes = vec![Nl80211Attr::IfIndex(self.if_index)];
+        if let Some(mac) = self.mac {
+            attributes.push(Nl80211Attr::Mac(mac));
+        }
+        attributes.push(Nl80211Attr::Key(key));
+        attributes
+    }
+}
+
+/// Sends a `NL80211_CMD_NEW_KEY` request.
+pub struct Nl80211KeyRequest {
+    handle: Nl80211Handle,
+    attributes: Vec<Nl80211Attr>,
+}
+
+impl Nl80211KeyRequest {
+    pub(crate) fn new(
+        handle: Nl80211Handle,
+        attributes: Vec<Nl80211Attr>,
+    ) -> Self {
+        Nl80211KeyRequest { handle, attributes }
+    }
+
+    /// Send the `NL80211_CMD_NEW_KEY` request.
+    ///
+    /// A successful return only means the key was accepted by the kernel.
+    pub async fn execute(
+        self,
+    ) -> impl TryStream<Ok = GenlMessage<Nl80211Message>, Error = Nl80211Error>
+    {
+        let Nl80211KeyRequest {
+            mut handle,
+            attributes,
+        } = self;
+        let nl80211_msg = Nl80211Message {
+            cmd: Nl80211Command::NewKey,
+            attributes,
+        };
+        nl80211_execute(&mut handle, nl80211_msg, NLM_F_REQUEST | NLM_F_ACK)
+            .await
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,10 +17,12 @@ mod frame_type;
 mod handle;
 mod iface;
 mod key;
+mod key_request;
 mod macros;
 mod message;
 mod mlo;
 mod rekey;
+mod rekey_request;
 mod scan;
 mod station;
 mod stats;
@@ -85,9 +87,13 @@ pub use self::iface::{
     Nl80211InterfaceVendorRequest, Nl80211NewInterface, Nl80211Vendor,
 };
 pub use self::key::{Nl80211KeyAttr, Nl80211KeyDefaultType, Nl80211KeyType};
+pub use self::key_request::{Nl80211Key, Nl80211KeyRequest};
 pub use self::message::Nl80211Message;
 pub use self::mlo::Nl80211MloLink;
 pub use self::rekey::Nl80211RekeyData;
+pub use self::rekey_request::{
+    Nl80211RekeyOffload, Nl80211RekeyOffloadRequest,
+};
 pub use self::scan::{
     Nl80211BssCapabilities, Nl80211BssInfo, Nl80211BssUseFor, Nl80211Scan,
     Nl80211ScanFlags, Nl80211ScanGetRequest, Nl80211ScanHandle,

--- a/src/rekey_request.rs
+++ b/src/rekey_request.rs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+
+use futures::TryStream;
+use netlink_packet_core::{NLM_F_ACK, NLM_F_REQUEST};
+use netlink_packet_generic::GenlMessage;
+
+use crate::{
+    nl80211_execute, Nl80211AkmSuite, Nl80211Attr, Nl80211Command,
+    Nl80211Error, Nl80211Handle, Nl80211Message, Nl80211RekeyData,
+};
+
+/// Helper to build the attribute list for a `NL80211_CMD_SET_REKEY_OFFLOAD`
+/// request, handing GTK rekey material to the driver/firmware so the device
+/// can keep receiving while the host is suspended.
+///
+/// Only drivers/firmware advertising rekey offload support it;
+/// mac80211_hwsim replies `-EOPNOTSUPP`.
+#[derive(Debug)]
+pub struct Nl80211RekeyOffload;
+
+impl Nl80211RekeyOffload {
+    /// Start building a `NL80211_CMD_SET_REKEY_OFFLOAD` request for
+    /// `if_index`.
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(if_index: u32) -> Nl80211RekeyOffloadRequestBuilder {
+        Nl80211RekeyOffloadRequestBuilder {
+            if_index,
+            kek: Vec::new(),
+            kck: Vec::new(),
+            replay_ctr: Vec::new(),
+            akm: Nl80211AkmSuite::Sae,
+        }
+    }
+}
+
+/// Builder for the attributes of a `NL80211_CMD_SET_REKEY_OFFLOAD` request.
+#[derive(Debug)]
+pub struct Nl80211RekeyOffloadRequestBuilder {
+    if_index: u32,
+    kek: Vec<u8>,
+    kck: Vec<u8>,
+    replay_ctr: Vec<u8>,
+    akm: Nl80211AkmSuite,
+}
+
+impl Nl80211RekeyOffloadRequestBuilder {
+    /// Key Encryption Key (16-32 bytes depending on AKM).
+    pub fn kek(mut self, kek: Vec<u8>) -> Self {
+        self.kek = kek;
+        self
+    }
+
+    /// Key Confirmation Key (16-24 bytes depending on AKM).
+    pub fn kck(mut self, kck: Vec<u8>) -> Self {
+        self.kck = kck;
+        self
+    }
+
+    /// Replay counter (8 bytes).
+    pub fn replay_ctr(mut self, replay_ctr: [u8; 8]) -> Self {
+        self.replay_ctr = replay_ctr.to_vec();
+        self
+    }
+
+    /// AKM suite, e.g. [`Nl80211AkmSuite::Sae`].
+    pub fn akm(mut self, akm: Nl80211AkmSuite) -> Self {
+        self.akm = akm;
+        self
+    }
+
+    /// Build the attribute list for a `NL80211_CMD_SET_REKEY_OFFLOAD`
+    /// request.
+    pub fn build(self) -> Vec<Nl80211Attr> {
+        // `Nl80211AkmSuite` stores the 802.11 element byte-order; the
+        // netlink `NL80211_REKEY_DATA_AKM` attribute expects the kernel's
+        // u32 (OUI in the high bytes), so swap.
+        let akm = u32::from(self.akm).swap_bytes();
+        vec![
+            Nl80211Attr::IfIndex(self.if_index),
+            Nl80211Attr::RekeyData(vec![
+                Nl80211RekeyData::Kek(self.kek),
+                Nl80211RekeyData::Kck(self.kck),
+                Nl80211RekeyData::ReplayCtr(self.replay_ctr),
+                Nl80211RekeyData::Akm(akm),
+            ]),
+        ]
+    }
+}
+
+/// Sends a `NL80211_CMD_SET_REKEY_OFFLOAD` request.
+pub struct Nl80211RekeyOffloadRequest {
+    handle: Nl80211Handle,
+    attributes: Vec<Nl80211Attr>,
+}
+
+impl Nl80211RekeyOffloadRequest {
+    pub(crate) fn new(
+        handle: Nl80211Handle,
+        attributes: Vec<Nl80211Attr>,
+    ) -> Self {
+        Nl80211RekeyOffloadRequest { handle, attributes }
+    }
+
+    /// Send the `NL80211_CMD_SET_REKEY_OFFLOAD` request.
+    ///
+    /// A successful return only means the request was accepted by the
+    /// driver; unsupported drivers reply with a netlink error.
+    pub async fn execute(
+        self,
+    ) -> impl TryStream<Ok = GenlMessage<Nl80211Message>, Error = Nl80211Error>
+    {
+        let Nl80211RekeyOffloadRequest {
+            mut handle,
+            attributes,
+        } = self;
+        let nl80211_msg = Nl80211Message {
+            cmd: Nl80211Command::SetRekeyOffload,
+            attributes,
+        };
+        nl80211_execute(&mut handle, nl80211_msg, NLM_F_REQUEST | NLM_F_ACK)
+            .await
+    }
+}

--- a/src/tests/key.rs
+++ b/src/tests/key.rs
@@ -8,9 +8,12 @@
 // parsing and emitting against exactly what wpa_supplicant and the kernel
 // exchange.
 
-use netlink_packet_core::{Emitable, NlaBuffer, Parseable};
+use netlink_packet_core::{Emitable, NlaBuffer, NlasIterator, Parseable};
 
-use crate::{Nl80211Attr, Nl80211KeyAttr, Nl80211KeyDefaultType};
+use crate::{
+    Nl80211Attr, Nl80211CipherSuite, Nl80211Command, Nl80211Key,
+    Nl80211KeyAttr, Nl80211KeyDefaultType, Nl80211KeyType, Nl80211Message,
+};
 
 fn assert_roundtrip(expected: Nl80211Attr, raw: Vec<u8>) {
     assert_eq!(
@@ -140,4 +143,129 @@ fn test_captured_set_key_group_default_types() {
         Nl80211KeyAttr::DefaultTypes(vec![Nl80211KeyDefaultType::Multicast]),
     ]);
     assert_roundtrip(expected, raw);
+}
+
+// Full `NL80211_CMD_NEW_KEY` request messages (WPA2-PSK "Test-WIFI", AP
+// BSSID 02:00:00:00:01:00, ifindex 464), captured on the `nl0` nlmon
+// monitor while wpa_supplicant connected. The emitted attribute region must
+// byte-match the captured message exactly.
+
+fn emit_new_key_attributes(attributes: Vec<Nl80211Attr>) -> Vec<u8> {
+    let msg = Nl80211Message {
+        cmd: Nl80211Command::NewKey,
+        attributes,
+    };
+    let mut buf = vec![0u8; msg.buffer_len()];
+    msg.emit(&mut buf);
+    buf
+}
+
+fn parse_message_attributes(raw: &[u8]) -> Vec<Nl80211Attr> {
+    NlasIterator::new(raw)
+        .map(|nla| Nl80211Attr::parse(&nla.unwrap()).unwrap())
+        .collect()
+}
+
+// Installing the pairwise (CCMP-128) key: NL80211_ATTR_IFINDEX,
+// NL80211_ATTR_MAC, then NL80211_ATTR_KEY with KEY_DATA, KEY_CIPHER
+// (00-0f-ac:4), KEY_SEQ (6-byte RSC) and KEY_IDX (0).
+#[test]
+fn test_captured_new_key_message_pairwise() {
+    // nlmsghdr(16) + genl header(4), attributes start at offset 20.
+    let raw = vec![
+        0x5c, 0x00, 0x00, 0x00, 0x32, 0x00, 0x05, 0x00, 0xca, 0x75, 0x8e, 0x95,
+        0xa7, 0x9b, 0xc0, 0xf4, 0x0b, 0x00, 0x00, 0x00, 0x08, 0x00, 0x03, 0x00,
+        0xd0, 0x01, 0x00, 0x00, 0x0a, 0x00, 0x06, 0x00, 0x02, 0x00, 0x00, 0x00,
+        0x01, 0x00, 0x00, 0x00, 0x34, 0x00, 0x50, 0x00, 0x14, 0x00, 0x01, 0x00,
+        0x7d, 0x94, 0x07, 0x6d, 0x81, 0x6d, 0x04, 0x86, 0xbf, 0x22, 0x80, 0xa9,
+        0x56, 0xa7, 0xe6, 0x51, 0x08, 0x00, 0x03, 0x00, 0x04, 0xac, 0x0f, 0x00,
+        0x0a, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x05, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ];
+    assert_eq!(92, raw.len());
+    let attributes = Nl80211Key::new(464)
+        .mac([0x02, 0x00, 0x00, 0x00, 0x01, 0x00])
+        .key_data(vec![
+            0x7d, 0x94, 0x07, 0x6d, 0x81, 0x6d, 0x04, 0x86, 0xbf, 0x22, 0x80,
+            0xa9, 0x56, 0xa7, 0xe6, 0x51,
+        ])
+        .key_index(0)
+        .cipher(Nl80211CipherSuite::Ccmp128)
+        .seq(vec![0u8; 6])
+        .build();
+    assert_eq!(&raw[20..], emit_new_key_attributes(attributes));
+}
+
+// Installing the group key (CCMP-128) at index 1: same shape but no
+// NL80211_ATTR_MAC and KEY_IDX (1).
+#[test]
+fn test_captured_new_key_message_group() {
+    let raw = vec![
+        0x50, 0x00, 0x00, 0x00, 0x32, 0x00, 0x05, 0x00, 0xcb, 0x75, 0x8e, 0x95,
+        0xa7, 0x9b, 0xc0, 0xf4, 0x0b, 0x00, 0x00, 0x00, 0x08, 0x00, 0x03, 0x00,
+        0xd0, 0x01, 0x00, 0x00, 0x34, 0x00, 0x50, 0x00, 0x14, 0x00, 0x01, 0x00,
+        0xb6, 0x29, 0xc4, 0x84, 0x95, 0x0e, 0x72, 0x3e, 0x1e, 0xfc, 0xe5, 0x31,
+        0x1e, 0x68, 0x2d, 0xf8, 0x08, 0x00, 0x03, 0x00, 0x04, 0xac, 0x0f, 0x00,
+        0x0a, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x05, 0x00, 0x02, 0x00, 0x01, 0x00, 0x00, 0x00,
+    ];
+    assert_eq!(80, raw.len());
+    let attributes = Nl80211Key::new(464)
+        .key_data(vec![
+            0xb6, 0x29, 0xc4, 0x84, 0x95, 0x0e, 0x72, 0x3e, 0x1e, 0xfc, 0xe5,
+            0x31, 0x1e, 0x68, 0x2d, 0xf8,
+        ])
+        .key_index(1)
+        .cipher(Nl80211CipherSuite::Ccmp128)
+        .seq(vec![0u8; 6])
+        .build();
+    assert_eq!(&raw[20..], emit_new_key_attributes(attributes));
+}
+
+// The convenience constructors add what wpa_supplicant leaves off the wire:
+// NL80211_KEY_TYPE, and for the GTK the default-multicast
+// NL80211_KEY_DEFAULT_TYPES (the SET_KEY form of which is validated against
+// a capture above).
+#[test]
+fn test_new_key_conveniences() {
+    let ptk = emit_new_key_attributes(
+        Nl80211Key::new_ptk(
+            464,
+            [0x02, 0x00, 0x00, 0x00, 0x01, 0x00],
+            vec![0xaa; 16],
+        )
+        .build(),
+    );
+    assert_eq!(
+        vec![
+            Nl80211Attr::IfIndex(464),
+            Nl80211Attr::Mac([0x02, 0x00, 0x00, 0x00, 0x01, 0x00]),
+            Nl80211Attr::Key(vec![
+                Nl80211KeyAttr::Data(vec![0xaa; 16]),
+                Nl80211KeyAttr::Cipher(0x000F_AC04),
+                Nl80211KeyAttr::Idx(0),
+                Nl80211KeyAttr::Type(Nl80211KeyType::Pairwise),
+            ]),
+        ],
+        parse_message_attributes(&ptk)
+    );
+
+    let gtk = emit_new_key_attributes(
+        Nl80211Key::new_gtk(464, vec![0xbb; 16], 1).build(),
+    );
+    assert_eq!(
+        vec![
+            Nl80211Attr::IfIndex(464),
+            Nl80211Attr::Key(vec![
+                Nl80211KeyAttr::Data(vec![0xbb; 16]),
+                Nl80211KeyAttr::Cipher(0x000F_AC04),
+                Nl80211KeyAttr::Idx(1),
+                Nl80211KeyAttr::Type(Nl80211KeyType::Group),
+                Nl80211KeyAttr::DefaultTypes(vec![
+                    Nl80211KeyDefaultType::Multicast
+                ]),
+            ]),
+        ],
+        parse_message_attributes(&gtk)
+    );
 }


### PR DESCRIPTION
Introduce Nl80211Key / Nl80211KeyRequest to install the PTK / GTK via
NL80211_CMD_NEW_KEY, and Nl80211RekeyOffload / Nl80211RekeyOffloadRequest
for NL80211_CMD_SET_REKEY_OFFLOAD (WoWLAN GTK rekey material).

Example:

    handle.connection()
        .new_key(Nl80211Key::new_ptk(if_index, peer_mac, ptk).build())
        .execute()
        .await?;

Convenience builders new_ptk() / new_gtk() default to CCMP-128 and mark
the group key as default multicast via NL80211_KEY_DEFAULT_TYPES. Both
requests are exposed through Nl80211ConnectionHandle, alongside the
existing connect / associate / frame builders.

Unit tests round-trip full NL80211_CMD_NEW_KEY messages captured on an
nlmon interface (wpa_supplicant + hostapd on mac80211_hwsim). The
SET_REKEY_OFFLOAD request is not covered by an on-wire test because hwsim
does not support WoWLAN.