### PR TITLE
BREAKING CHANGE: `Nl80211Attr::ControlPortEthertype` now holds `EthernetProtocol`

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -31,8 +31,8 @@
 
 use netlink_packet_core::{
     parse_string, parse_u16, parse_u32, parse_u64, parse_u8, DecodeError,
-    DefaultNla, Emitable, ErrorContext, Nla, NlaBuffer, NlasIterator,
-    Parseable, ParseableParametrized,
+    DefaultNla, Emitable, ErrorContext, EthernetProtocol, Nla, NlaBuffer,
+    NlasIterator, Parseable, ParseableParametrized,
 };
 
 use crate::{
@@ -570,8 +570,8 @@ pub enum Nl80211Attr {
     MaxNumPmkids(u8),
     /// EtherType of the control-port (802.1X/EAPOL) frames, used with
     /// `NL80211_CMD_CONTROL_PORT_FRAME` and on connect/associate. Typically
-    /// `0x888E` (ETH_P_PAE).
-    ControlPortEthertype(u16),
+    /// [`EthernetProtocol::Pae`] (`ETH_P_PAE`, `0x888E`).
+    ControlPortEthertype(EthernetProtocol),
     /// Flag attribute requesting that the control-port (802.1X/EAPOL) frames
     /// be transmitted unencrypted (`NL80211_ATTR_CONTROL_PORT_NO_ENCRYPT`).
     ControlPortNoEncrypt,
@@ -1048,7 +1048,7 @@ impl Nla for Nl80211Attr {
                 buffer[..s.len()].copy_from_slice(s.as_bytes());
             }
             Self::Use4Addr(d) => buffer[0] = *d as u8,
-            Self::ControlPortEthertype(d) => write_u16(buffer, *d),
+            Self::ControlPortEthertype(d) => write_u16(buffer, d.value()),
             Self::SupportIbssRsn
             | Self::SupportMeshAuth
             | Self::SupportApUapsd
@@ -1459,7 +1459,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nl80211Attr {
                 let err_msg = format!(
                     "Invalid NL80211_ATTR_CONTROL_PORT_ETHERTYPE {payload:?}"
                 );
-                Self::ControlPortEthertype(parse_u16(payload).context(err_msg)?)
+                Self::ControlPortEthertype(EthernetProtocol::from(
+                    parse_u16(payload).context(err_msg)?,
+                ))
             }
             NL80211_ATTR_WIPHY_ANTENNA_AVAIL_TX => {
                 let err_msg = format!(

--- a/src/connect/assoc.rs
+++ b/src/connect/assoc.rs
@@ -100,7 +100,7 @@ impl Nl80211AttrsBuilder<Nl80211Associate> {
     /// Ethernet protocol of the control port frames (normally
     /// [`EthernetProtocol::Pae`], `ETH_P_PAE` = 0x888E).
     pub fn control_port_ethertype(self, ethertype: EthernetProtocol) -> Self {
-        self.replace(Nl80211Attr::ControlPortEthertype(u16::from(ethertype)))
+        self.replace(Nl80211Attr::ControlPortEthertype(ethertype))
     }
 }
 

--- a/src/connect/frame.rs
+++ b/src/connect/frame.rs
@@ -172,7 +172,7 @@ impl Nl80211AttrsBuilder<Nl80211ControlPortFrame> {
     /// EtherType of the control port frames, e.g.
     /// [`EthernetProtocol::Pae`] (`ETH_P_PAE`, 0x888E) for EAPOL.
     pub fn control_port_ethertype(self, ethertype: EthernetProtocol) -> Self {
-        self.replace(Nl80211Attr::ControlPortEthertype(u16::from(ethertype)))
+        self.replace(Nl80211Attr::ControlPortEthertype(ethertype))
     }
 
     /// Whether the frames should be transmitted unencrypted

--- a/src/tests/key.rs
+++ b/src/tests/key.rs
@@ -8,7 +8,9 @@
 // parsing and emitting against exactly what wpa_supplicant and the kernel
 // exchange.
 
-use netlink_packet_core::{Emitable, NlaBuffer, NlasIterator, Parseable};
+use netlink_packet_core::{
+    Emitable, EthernetProtocol, NlaBuffer, NlasIterator, Parseable,
+};
 
 use crate::{
     Nl80211Attr, Nl80211CipherSuite, Nl80211Command, Nl80211Key,
@@ -62,7 +64,10 @@ fn test_captured_auth_data_confirm() {
 #[test]
 fn test_captured_control_port_ethertype() {
     let raw = vec![0x06, 0x00, 0x66, 0x00, 0x8e, 0x88, 0x00, 0x00];
-    assert_roundtrip(Nl80211Attr::ControlPortEthertype(0x888E), raw);
+    assert_roundtrip(
+        Nl80211Attr::ControlPortEthertype(EthernetProtocol::from(0x888E)),
+        raw,
+    );
 }
 
 // Nested NL80211_ATTR_KEY from CMD_NEW_KEY installing the pairwise (CCMP-128)


### PR DESCRIPTION
The attribute payload changes from a raw `u16` to the typed
`netlink_packet_core::EthernetProtocol`.