### PR TITLE
fix: NL80211_ATTR_CONTROL_PORT_ETHERTYPE is also a zero-length wiphy flag

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -572,6 +572,13 @@ pub enum Nl80211Attr {
     /// `NL80211_CMD_CONTROL_PORT_FRAME` and on connect/associate. Typically
     /// [`EthernetProtocol::Pae`] (`ETH_P_PAE`, `0x888E`).
     ControlPortEthertype(EthernetProtocol),
+    /// `NL80211_ATTR_CONTROL_PORT_ETHERTYPE` sent as a **zero-length flag** in
+    /// wiphy information, where the kernel uses the same attribute id to mean
+    /// "protocols other than PAE are supported" rather than to carry a value.
+    ///
+    /// Per `nl80211.h`: "This attribute is also used as a flag in the wiphy
+    /// information to indicate that protocols other than PAE are supported."
+    ControlPortEthertypeSupported,
     /// Flag attribute requesting that the control-port (802.1X/EAPOL) frames
     /// be transmitted unencrypted (`NL80211_ATTR_CONTROL_PORT_NO_ENCRYPT`).
     ControlPortNoEncrypt,
@@ -814,6 +821,7 @@ impl Nla for Nl80211Attr {
             Self::MloLinks(links) => links.as_slice().buffer_len(),
             Self::MaxScanIeLen(_) | Self::MaxSchedScanIeLen(_) => 2,
             Self::ControlPortEthertype(_) => 2,
+            Self::ControlPortEthertypeSupported => 0,
             Self::SupportIbssRsn
             | Self::SupportMeshAuth
             | Self::SupportApUapsd
@@ -946,7 +954,8 @@ impl Nla for Nl80211Attr {
             Self::TdlsExternalSetup => NL80211_ATTR_TDLS_EXTERNAL_SETUP,
             Self::CipherSuites(_) => NL80211_ATTR_CIPHER_SUITES,
             Self::MaxNumPmkids(_) => NL80211_ATTR_MAX_NUM_PMKIDS,
-            Self::ControlPortEthertype(_) => {
+            Self::ControlPortEthertype(_)
+            | Self::ControlPortEthertypeSupported => {
                 NL80211_ATTR_CONTROL_PORT_ETHERTYPE
             }
             Self::WiphyAntennaAvailTx(_) => NL80211_ATTR_WIPHY_ANTENNA_AVAIL_TX,
@@ -1102,7 +1111,8 @@ impl Nla for Nl80211Attr {
             | Self::TdlsExternalSetup
             | Self::OffchannelTxOk
             | Self::SurveyRadioStats
-            | Self::WiphySelfManagedReg => (),
+            | Self::WiphySelfManagedReg
+            | Self::ControlPortEthertypeSupported => (),
             Self::WiphyChannelType(d) => write_u32(buffer, (*d).into()),
             Self::ChannelWidth(d) => write_u32(buffer, (*d).into()),
             Self::StationInfo(nlas) => nlas.as_slice().emit(buffer),
@@ -1511,12 +1521,22 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nl80211Attr {
                 Self::MaxNumPmkids(parse_u8(payload).context(err_msg)?)
             }
             NL80211_ATTR_CONTROL_PORT_ETHERTYPE => {
-                let err_msg = format!(
-                    "Invalid NL80211_ATTR_CONTROL_PORT_ETHERTYPE {payload:?}"
-                );
-                Self::ControlPortEthertype(EthernetProtocol::from(
-                    parse_u16(payload).context(err_msg)?,
-                ))
+                // Dual-purpose attribute: a u16 ethertype on connect/associate,
+                // but a zero-length FLAG in wiphy information, where it means
+                // "protocols other than PAE are supported" (nl80211.h).
+                // Treating the flag form as a malformed u16 makes every
+                // NL80211_CMD_GET_WIPHY dump unparseable on hardware that
+                // advertises it.
+                if payload.is_empty() {
+                    Self::ControlPortEthertypeSupported
+                } else {
+                    let err_msg = format!(
+                        "Invalid NL80211_ATTR_CONTROL_PORT_ETHERTYPE {payload:?}"
+                    );
+                    Self::ControlPortEthertype(EthernetProtocol::from(
+                        parse_u16(payload).context(err_msg)?,
+                    ))
+                }
             }
             NL80211_ATTR_WIPHY_ANTENNA_AVAIL_TX => {
                 let err_msg = format!(

--- a/src/tests/control_port_frame.rs
+++ b/src/tests/control_port_frame.rs
@@ -67,3 +67,49 @@ fn test_captured_control_port_frame_request() {
     built.sort_by_key(|attr| attr.kind());
     assert_eq!(captured, built);
 }
+
+// Regression: `NL80211_ATTR_CONTROL_PORT_ETHERTYPE` (102 / 0x66) is
+// dual-purpose. On connect/associate it carries a u16 ethertype, but in wiphy
+// information the kernel emits it ZERO-LENGTH as a flag meaning "protocols
+// other than PAE are supported" (nl80211.h). Parsing the flag form as a u16
+// fails, and because attribute parsing is fail-fast a single flag makes an
+// entire NL80211_CMD_GET_WIPHY dump unreadable.
+//
+// Attribute region from a real GET_WIPHY dump: Intel AX211 (iwlwifi) on
+// Linux 7.0.0-22-generic. `04 00 66 00` is nla_len=4 (header only, no payload),
+// nla_type=102.
+#[test]
+fn test_control_port_ethertype_zero_length_flag_in_wiphy() {
+    let raw = vec![
+        0x08, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, // Wiphy(1)
+        0x04, 0x00, 0x66,
+        0x00, // CONTROL_PORT_ETHERTYPE, zero-length flag
+        0x08, 0x00, 0x71, 0x00, 0x03, 0x00, 0x00,
+        0x00, // WiphyAntennaAvailTx(3)
+    ];
+    let attrs = parse_message_attributes(&raw);
+    assert_eq!(
+        vec![
+            Nl80211Attr::Wiphy(1),
+            Nl80211Attr::ControlPortEthertypeSupported,
+            Nl80211Attr::WiphyAntennaAvailTx(3),
+        ],
+        attrs
+    );
+}
+
+// The u16 form still parses, and both forms carry the same attribute id with
+// the lengths the kernel expects.
+#[test]
+fn test_control_port_ethertype_both_forms() {
+    let value = Nl80211Attr::ControlPortEthertype(EthernetProtocol::Pae);
+    let flag = Nl80211Attr::ControlPortEthertypeSupported;
+
+    assert_eq!(value.kind(), flag.kind());
+    assert_eq!(2, value.value_len());
+    assert_eq!(0, flag.value_len());
+
+    // The u16 form round-trips through a 2-byte payload.
+    let raw = vec![0x06, 0x00, 0x66, 0x00, 0x8e, 0x88, 0x00, 0x00];
+    assert_eq!(vec![value], parse_message_attributes(&raw));
+}


### PR DESCRIPTION
`NL80211_ATTR_CONTROL_PORT_ETHERTYPE` is dual-purpose, and only one purpose is currently handled.

Commit 0a24d33b correctly established that connect/associate carry it as a `u16`. The kernel also emits it **zero-length as a flag** in wiphy information — from `nl80211.h`:

> `@NL80211_ATTR_CONTROL_PORT_ETHERTYPE`: A 16-bit value indicating the ethertype that will be used for key negotiation. It can be specified with the associate and connect commands. If it is not specified, the value defaults to 0x888E (PAE, 802.1X). **This attribute is also used as a flag in the wiphy information to indicate that protocols other than PAE are supported.**

Because `parse_u16` fails on an empty payload and attribute parsing is fail-fast, **a single flag makes an entire `NL80211_CMD_GET_WIPHY` dump unparseable.**

## Reproduction

Linux 7.0.0-22-generic (Ubuntu 26.04). `cargo run --example dump_nl80211_wiphy` panics on the **first** message, for both an Intel AX211 (`iwlwifi`) and an Alfa AWUS036ACM / MT7612U (`mt76x2u`):

```
Bug("BUG: decode error DecodeError { msg: "Failed to parse nl80211 message
attribute caused by Invalid NL80211_ATTR_CONTROL_PORT_ETHERTYPE []
caused by Invalid number. Expected 2 bytes, received 0 bytes" }")
```

The offending attribute on the wire is `04 00 66 00` — `nla_len` 4 (header only, no payload), `nla_type` 102.

## Fix

Add a distinct `Nl80211Attr::ControlPortEthertypeSupported` variant for the flag form and dispatch on payload length: empty is the flag, otherwise the `u16`.

The emit side mirrors the crate's existing zero-length wiphy flags (`SupportIbssRsn`, `TdlsSupport`, `WiphySelfManagedReg`, …) — same attribute id, `value_len` 0, no value written — so both forms round-trip.

**Non-breaking.** Keeping the two as separate variants rather than folding into an `Option` leaves the `u16` API from 0a24d33b unchanged, and makes the wiphy capability explicit at the call site.

## Tests

- A regression test parsing the zero-length flag from a real `GET_WIPHY` attribute region.
- One asserting both forms share an attribute id with the lengths the kernel expects.

## Verification

From a clean clone of `ac6a6c6` (v0.5.0) with this patch applied:

- `cargo test` — **66 passed**, 0 failed (64 existing + 2 new)
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- MSRV 1.77 unaffected (no new language features)
- `dump_nl80211_wiphy` parses **201 wiphy messages** across both radios, including the AX211's 6 GHz band

Happy to adjust the variant name or split the tests differently if you'd prefer a different shape.
