### PR TITLE
scan: Group sched scan match/plan attrs into nested sets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,8 @@ pub use self::scan::{
     Nl80211BssCapabilities, Nl80211BssInfo, Nl80211BssUseFor, Nl80211Scan,
     Nl80211ScanFlags, Nl80211ScanGetRequest, Nl80211ScanHandle,
     Nl80211ScanScheduleRequest, Nl80211ScanScheduleStopRequest,
-    Nl80211ScanTriggerRequest, Nl80211SchedScanMatch, Nl80211SchedScanPlan,
+    Nl80211ScanTriggerRequest, Nl80211SchedScanMatch,
+    Nl80211SchedScanMatchAttr, Nl80211SchedScanPlan, Nl80211SchedScanPlanAttr,
 };
 pub use self::station::{
     Nl80211EhtGi, Nl80211EhtRuAllocation, Nl80211HeGi, Nl80211HeRuAllocation,

--- a/src/scan/mod.rs
+++ b/src/scan/mod.rs
@@ -15,7 +15,8 @@ pub use self::get::Nl80211ScanGetRequest;
 pub use self::handle::{Nl80211Scan, Nl80211ScanHandle};
 pub use self::schedule::{
     Nl80211ScanScheduleRequest, Nl80211ScanScheduleStopRequest,
-    Nl80211SchedScanMatch, Nl80211SchedScanPlan,
+    Nl80211SchedScanMatch, Nl80211SchedScanMatchAttr, Nl80211SchedScanPlan,
+    Nl80211SchedScanPlanAttr,
 };
 pub use self::trigger::Nl80211ScanTriggerRequest;
 

--- a/src/scan/schedule.rs
+++ b/src/scan/schedule.rs
@@ -3,7 +3,8 @@
 use futures::TryStream;
 use netlink_packet_core::{
     parse_i32, parse_string, parse_u32, DecodeError, DefaultNla, Emitable,
-    ErrorContext, Nla, NlaBuffer, Parseable, NLM_F_ACK, NLM_F_REQUEST,
+    ErrorContext, Nla, NlaBuffer, NlasIterator, Parseable, NLA_F_NESTED,
+    NLM_F_ACK, NLM_F_REQUEST,
 };
 use netlink_packet_generic::GenlMessage;
 
@@ -90,10 +91,44 @@ const NL80211_SCHED_SCAN_MATCH_ATTR_BSSID: u16 = 5;
 // Linux kernel has this one marked as obsolete
 // const NL80211_SCHED_SCAN_MATCH_PER_BAND_RSSI: u16 = 6;
 
+// The kernel parses `NL80211_ATTR_SCHED_SCAN_MATCH` as a list of match sets,
+// each match set being a nested attribute holding a group of match
+// attributes (`Nl80211SchedScanMatchAttr`).
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum Nl80211SchedScanMatch {
+pub struct Nl80211SchedScanMatch(pub Vec<Nl80211SchedScanMatchAttr>);
+
+impl Nla for Nl80211SchedScanMatch {
+    fn value_len(&self) -> usize {
+        self.0.as_slice().buffer_len()
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        self.0.as_slice().emit(buffer);
+    }
+
+    fn kind(&self) -> u16 {
+        NLA_F_NESTED
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
+    for Nl80211SchedScanMatch
+{
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let err = "Invalid NLA for NL80211_SCHED_SCAN_MATCH";
+        let mut attrs = Vec::new();
+        for nla in NlasIterator::new(buf.value()) {
+            let nla = &nla.context(err)?;
+            attrs.push(Nl80211SchedScanMatchAttr::parse(nla).context(err)?);
+        }
+        Ok(Self(attrs))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Nl80211SchedScanMatchAttr {
     /// SSID to be used for matching. Cannot use with
-    /// [Nl80211SchedScanMatch::Bssid].
+    /// [Nl80211SchedScanMatchAttr::Bssid].
     Ssid(String),
     /// RSSI threshold (in dBm) for reporting a BSS in scan results. Filtering
     /// is turned off if not specified. Note that if this attribute is in a
@@ -105,12 +140,12 @@ pub enum Nl80211SchedScanMatch {
     /// there's only a single matchset with the RSSI attribute.
     Rssi(i32),
     /// BSSID to be used for matching. Cannot use with
-    /// [Nl80211SchedScanMatch::Ssid].
+    /// [Nl80211SchedScanMatchAttr::Ssid].
     Bssid([u8; ETH_ALEN]),
     Other(DefaultNla),
 }
 
-impl Nla for Nl80211SchedScanMatch {
+impl Nla for Nl80211SchedScanMatchAttr {
     fn value_len(&self) -> usize {
         match self {
             Self::Ssid(v) => v.len(),
@@ -140,7 +175,7 @@ impl Nla for Nl80211SchedScanMatch {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
-    for Nl80211SchedScanMatch
+    for Nl80211SchedScanMatchAttr
 {
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = buf.value();
@@ -179,8 +214,42 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
 const NL80211_SCHED_SCAN_PLAN_INTERVAL: u16 = 1;
 const NL80211_SCHED_SCAN_PLAN_ITERATIONS: u16 = 2;
 
+// The kernel parses `NL80211_ATTR_SCHED_SCAN_PLANS` as a list of scan plans,
+// each scan plan being a nested attribute holding a group of plan attributes
+// (`Nl80211SchedScanPlanAttr`).
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum Nl80211SchedScanPlan {
+pub struct Nl80211SchedScanPlan(pub Vec<Nl80211SchedScanPlanAttr>);
+
+impl Nla for Nl80211SchedScanPlan {
+    fn value_len(&self) -> usize {
+        self.0.as_slice().buffer_len()
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        self.0.as_slice().emit(buffer);
+    }
+
+    fn kind(&self) -> u16 {
+        NLA_F_NESTED
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
+    for Nl80211SchedScanPlan
+{
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let err = "Invalid NLA for NL80211_SCHED_SCAN_PLANS";
+        let mut attrs = Vec::new();
+        for nla in NlasIterator::new(buf.value()) {
+            let nla = &nla.context(err)?;
+            attrs.push(Nl80211SchedScanPlanAttr::parse(nla).context(err)?);
+        }
+        Ok(Self(attrs))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Nl80211SchedScanPlanAttr {
     /// Interval between scan iterations in seconds.
     Interval(u32),
     /// Number of scan iterations in this scan plan. The last scan plan
@@ -190,7 +259,7 @@ pub enum Nl80211SchedScanPlan {
     Other(DefaultNla),
 }
 
-impl Nla for Nl80211SchedScanPlan {
+impl Nla for Nl80211SchedScanPlanAttr {
     fn value_len(&self) -> usize {
         match self {
             Self::Interval(_) => 4,
@@ -216,7 +285,7 @@ impl Nla for Nl80211SchedScanPlan {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
-    for Nl80211SchedScanPlan
+    for Nl80211SchedScanPlanAttr
 {
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = buf.value();

--- a/src/tests/scan.rs
+++ b/src/tests/scan.rs
@@ -2,7 +2,7 @@
 
 use crate::*;
 use netlink_packet_core::{
-    Emitable, NetlinkDeserializable, NetlinkHeader, Parseable,
+    Emitable, NetlinkDeserializable, NetlinkHeader, NlaBuffer, Parseable,
 };
 use netlink_packet_generic::{GenlHeader, GenlMessage};
 
@@ -240,6 +240,68 @@ fn test_parse_ies() {
     ]);
 
     assert_eq!(expected, Nl80211Elements::parse(&raw).unwrap());
+
+    let mut buf = vec![0; expected.buffer_len()];
+
+    expected.emit(&mut buf);
+
+    assert_eq!(buf, raw);
+}
+
+// The kernel parses `NL80211_ATTR_SCHED_SCAN_MATCH` as a list of match sets,
+// each match set being a nested attribute holding a group of match
+// attributes. Regression test for the previous flat emission which made the
+// kernel log "netlink: N bytes leftover after parsing attributes".
+#[test]
+fn test_sched_scan_match_nested_attrs() {
+    let raw = vec![
+        // outer: kind=NL80211_ATTR_SCHED_SCAN_MATCH, len = 4 + 24 = 28
+        28, 0, 132, 0,
+        // matchset: kind=NLA_F_NESTED, len = 4 + 20 = 24
+        24, 0, 0x00, 0x80,
+        // ssid: kind=1, len=18, value (padded to 20 bytes)
+        18, 0, 1, 0, 0x48, 0x55, 0x41, 0x5a, 0x48, 0x55, 0x2d, 0x48, 0x61, 0x6e,
+        0x74, 0x69, 0x6e, 0x67, 0, 0,
+    ];
+
+    let expected =
+        Nl80211Attr::SchedScanMatch(vec![Nl80211SchedScanMatch(vec![
+            Nl80211SchedScanMatchAttr::Ssid("HUAZHU-Hanting".to_string()),
+        ])]);
+
+    assert_eq!(
+        expected,
+        Nl80211Attr::parse(&NlaBuffer::new_checked(&raw).unwrap()).unwrap()
+    );
+
+    let mut buf = vec![0; expected.buffer_len()];
+
+    expected.emit(&mut buf);
+
+    assert_eq!(buf, raw);
+}
+
+// Same as test_sched_scan_match_nested_attrs for NL80211_ATTR_SCHED_SCAN_PLANS:
+// the kernel parses it as a list of scan plans, each being a nested attribute
+// holding a group of plan attributes.
+#[test]
+fn test_sched_scan_plans_nested_attrs() {
+    let raw = vec![
+        // outer: kind=NL80211_ATTR_SCHED_SCAN_PLANS, len = 4 + 12 = 16
+        16, 0, 225, 0, // plan: kind=NLA_F_NESTED, len = 4 + 8 = 12
+        12, 0, 0x00, 0x80, // interval: kind=1, len=8, value
+        8, 0, 1, 0, 10, 0, 0, 0,
+    ];
+
+    let expected =
+        Nl80211Attr::SchedScanPlans(vec![Nl80211SchedScanPlan(vec![
+            Nl80211SchedScanPlanAttr::Interval(10),
+        ])]);
+
+    assert_eq!(
+        expected,
+        Nl80211Attr::parse(&NlaBuffer::new_checked(&raw).unwrap()).unwrap()
+    );
 
     let mut buf = vec![0; expected.buffer_len()];
 


### PR DESCRIPTION
Problem:

Given a scheduled scan (PNO) request carrying
NL80211_ATTR_SCHED_SCAN_MATCH or NL80211_ATTR_SCHED_SCAN_PLANS
When the crate emits the match/plan attributes
Then the kernel logs "netlink: N bytes leftover after parsing
attributes" and rejects the request with EINVAL

Root cause:

The kernel parses every child of NL80211_ATTR_SCHED_SCAN_MATCH as a
nested match set with nl80211_match_policy, and every child of
NL80211_ATTR_SCHED_SCAN_PLANS as a nested scan plan with
nl80211_plan_policy. The crate emitted the attributes flat instead,
so the kernel ran the policy parser over the raw payload.

Fix:

Turn `Nl80211SchedScanMatch` and `Nl80211SchedScanPlan` into structs
holding `Vec<Nl80211SchedScanMatchAttr>` and
`Vec<Nl80211SchedScanPlanAttr>`, and emit each match set/scan plan as
its own `NLA_F_NESTED` attribute, matching the kernel's two layer
nesting. The old enums are renamed to the `*Attr` types.

Unit test cases included.