### PR TITLE
Support roaming related attributes and commands

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -262,13 +262,13 @@ const NL80211_ATTR_WPA_VERSIONS: u16 = 75;
 const NL80211_ATTR_AKM_SUITES: u16 = 76;
 // const NL80211_ATTR_REQ_IE:u16 = 77;
 // const NL80211_ATTR_RESP_IE:u16 = 78;
-// const NL80211_ATTR_PREV_BSSID:u16 = 79;
+const NL80211_ATTR_PREV_BSSID: u16 = 79;
 const NL80211_ATTR_KEY: u16 = 80;
 // const NL80211_ATTR_KEYS:u16 = 81;
 // const NL80211_ATTR_PID:u16 = 82;
 const NL80211_ATTR_4ADDR: u16 = 83;
 const NL80211_ATTR_SURVEY_INFO: u16 = 84;
-// const NL80211_ATTR_PMKID:u16 = 85;
+const NL80211_ATTR_PMKID: u16 = 85;
 const NL80211_ATTR_MAX_NUM_PMKIDS: u16 = 86;
 // const NL80211_ATTR_DURATION:u16 = 87;
 const NL80211_ATTR_COOKIE: u16 = 88;
@@ -439,7 +439,7 @@ const NL80211_ATTR_BSSID: u16 = 245;
 // const NL80211_ATTR_FILS_ERP_NEXT_SEQ_NUM:u16 = 251;
 // const NL80211_ATTR_FILS_ERP_RRK:u16 = 252;
 // const NL80211_ATTR_FILS_CACHE_ID:u16 = 253;
-// const NL80211_ATTR_PMK:u16 = 254;
+const NL80211_ATTR_PMK: u16 = 254;
 // const NL80211_ATTR_SCHED_SCAN_MULTI:u16 = 255;
 const NL80211_ATTR_SCHED_SCAN_MAX_REQS: u16 = 256;
 // const NL80211_ATTR_WANT_1X_4WAY_HS:u16 = 257;
@@ -472,8 +472,8 @@ const NL80211_ATTR_TXQ_QUANTUM: u16 = 268;
 // const NL80211_ATTR_IFTYPE_AKM_SUITES:u16 = 284;
 // const NL80211_ATTR_TID_CONFIG:u16 = 285;
 // const NL80211_ATTR_CONTROL_PORT_NO_PREAUTH:u16 = 286;
-// const NL80211_ATTR_PMK_LIFETIME:u16 = 287;
-// const NL80211_ATTR_PMK_REAUTH_THRESHOLD:u16 = 288;
+const NL80211_ATTR_PMK_LIFETIME: u16 = 287;
+const NL80211_ATTR_PMK_REAUTH_THRESHOLD: u16 = 288;
 // const NL80211_ATTR_RECEIVE_MULTICAST:u16 = 289;
 const NL80211_ATTR_WIPHY_FREQ_OFFSET: u16 = 290;
 // const NL80211_ATTR_CENTER_FREQ1_OFFSET:u16 = 291;
@@ -708,6 +708,10 @@ pub enum Nl80211Attr {
     /// BSSID, used with `NL80211_CMD_EXTERNAL_AUTH` (distinct from the generic
     /// `NL80211_ATTR_MAC`).
     Bssid([u8; ETH_ALEN]),
+    /// BSSID of the BSS the station is currently associated with, used with
+    /// `NL80211_CMD_ASSOCIATE` to indicate a reassociation (roam) to a new
+    /// BSSID within the same ESS instead of a fresh association.
+    PrevBssid([u8; ETH_ALEN]),
     /// External authentication action (start/abort), used with
     /// `NL80211_CMD_EXTERNAL_AUTH`.
     ExternalAuthAction(Nl80211ExternalAuthAction),
@@ -722,6 +726,20 @@ pub enum Nl80211Attr {
     /// owns the created object (e.g. the connection), so it is destroyed when
     /// the socket is closed.
     SocketOwner,
+    /// PMK identifier (16 octets), used with `NL80211_CMD_SET_PMKSA` and
+    /// `NL80211_CMD_DEL_PMKSA` to address a driver PMKSA cache entry.
+    Pmkid(Vec<u8>),
+    /// Pairwise Master Key material, used with `NL80211_CMD_SET_PMKSA`
+    /// (together with [`Nl80211Attr::Pmkid`]) and `NL80211_CMD_SET_PMK` to
+    /// hand key material to the driver for offloaded key management.
+    Pmk(Vec<u8>),
+    /// Maximum lifetime of a driver PMKSA cache entry in seconds (u32), used
+    /// with `NL80211_CMD_SET_PMKSA`.
+    PmkLifetime(u32),
+    /// Reauthentication threshold in percent of [`Nl80211Attr::PmkLifetime`]
+    /// (u8): the driver should trigger reauthentication when this percentage
+    /// of the PMK lifetime has elapsed. Used with `NL80211_CMD_SET_PMKSA`.
+    PmkReauthThreshold(u8),
     Other(DefaultNla),
     /// 24-bit OUI, or an as yet unused Linux-specific ID.
     ///
@@ -763,6 +781,7 @@ impl Nla for Nl80211Attr {
             | Self::TransmitQueueQuantum(_)
             | Self::SchedScanInterval(_)
             | Self::SchedScanDelay(_)
+            | Self::PmkLifetime(_)
             | Self::VendorId(_)
             | Self::VendorSubcmd(_) => 4,
             Self::Wdev(_) => 8,
@@ -782,7 +801,8 @@ impl Nla for Nl80211Attr {
             | Self::MaxNumScanSsids(_)
             | Self::MaxNumSchedScanSsids(_)
             | Self::MaxMatchSets(_)
-            | Self::MaxNumPmkids(_) => 1,
+            | Self::MaxNumPmkids(_)
+            | Self::PmkReauthThreshold(_) => 1,
             Self::TransmitQueueStats(nlas) => nlas.as_slice().buffer_len(),
             Self::StationInfo(nlas) => nlas.as_slice().buffer_len(),
             Self::SurveyInfo(nlas) => nlas.as_slice().buffer_len(),
@@ -857,8 +877,12 @@ impl Nla for Nl80211Attr {
             Self::CiphersPairwise(s) => 4 * s.len(),
             Self::CipherGroup(_) => 4,
             Self::AkmSuites(s) => 4 * s.len(),
-            Self::Bssid(_) => ETH_ALEN,
-            Self::Ie(v) | Self::Frame(v) | Self::FrameMatch(v) => v.len(),
+            Self::Bssid(_) | Self::PrevBssid(_) => ETH_ALEN,
+            Self::Ie(v)
+            | Self::Frame(v)
+            | Self::FrameMatch(v)
+            | Self::Pmkid(v)
+            | Self::Pmk(v) => v.len(),
             Self::AuthData(v) => v.len(),
             Self::Key(nlas) => nlas.as_slice().buffer_len(),
             Self::RekeyData(nlas) => nlas.as_slice().buffer_len(),
@@ -999,6 +1023,7 @@ impl Nla for Nl80211Attr {
             Self::Cookie(_) => NL80211_ATTR_COOKIE,
             Self::Ack => NL80211_ATTR_ACK,
             Self::Bssid(_) => NL80211_ATTR_BSSID,
+            Self::PrevBssid(_) => NL80211_ATTR_PREV_BSSID,
             Self::ExternalAuthAction(_) => NL80211_ATTR_EXTERNAL_AUTH_ACTION,
             Self::ExternalAuthSupport => NL80211_ATTR_EXTERNAL_AUTH_SUPPORT,
             Self::ControlPortOverNl80211 => {
@@ -1006,6 +1031,10 @@ impl Nla for Nl80211Attr {
             }
             Self::ControlPortNoEncrypt => NL80211_ATTR_CONTROL_PORT_NO_ENCRYPT,
             Self::SocketOwner => NL80211_ATTR_SOCKET_OWNER,
+            Self::Pmkid(_) => NL80211_ATTR_PMKID,
+            Self::Pmk(_) => NL80211_ATTR_PMK,
+            Self::PmkLifetime(_) => NL80211_ATTR_PMK_LIFETIME,
+            Self::PmkReauthThreshold(_) => NL80211_ATTR_PMK_REAUTH_THRESHOLD,
             Self::Other(attr) => attr.kind(),
         }
     }
@@ -1036,6 +1065,7 @@ impl Nla for Nl80211Attr {
             | Self::TransmitQueueQuantum(d)
             | Self::SchedScanInterval(d)
             | Self::SchedScanDelay(d)
+            | Self::PmkLifetime(d)
             | Self::VendorId(d)
             | Self::VendorSubcmd(d) => write_u32(buffer, *d),
             Self::MaxScanIeLen(d) | Self::MaxSchedScanIeLen(d) => {
@@ -1078,7 +1108,8 @@ impl Nla for Nl80211Attr {
             | Self::MaxNumScanSsids(d)
             | Self::MaxNumSchedScanSsids(d)
             | Self::MaxMatchSets(d)
-            | Self::MaxNumPmkids(d) => buffer[0] = *d,
+            | Self::MaxNumPmkids(d)
+            | Self::PmkReauthThreshold(d) => buffer[0] = *d,
             Self::CipherSuites(suits) => {
                 let nums: Vec<u32> =
                     suits.as_slice().iter().map(|s| u32::from(*s)).collect();
@@ -1171,10 +1202,14 @@ impl Nla for Nl80211Attr {
                     );
                 }
             }
-            Self::Bssid(d) => buffer[..ETH_ALEN].copy_from_slice(d),
-            Self::Ie(v) | Self::Frame(v) | Self::FrameMatch(v) => {
-                buffer[..v.len()].copy_from_slice(v)
+            Self::Bssid(d) | Self::PrevBssid(d) => {
+                buffer[..ETH_ALEN].copy_from_slice(d)
             }
+            Self::Ie(v)
+            | Self::Frame(v)
+            | Self::FrameMatch(v)
+            | Self::Pmkid(v)
+            | Self::Pmk(v) => buffer[..v.len()].copy_from_slice(v),
             Self::AuthData(v) => buffer[..v.len()].copy_from_slice(v),
             Self::Key(nlas) => nlas.as_slice().emit(buffer),
             Self::RekeyData(nlas) => nlas.as_slice().emit(buffer),
@@ -1848,6 +1883,40 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nl80211Attr {
                         expected length {ETH_ALEN} got {payload:?}"
                     )
                 })?)
+            }
+            NL80211_ATTR_PREV_BSSID => {
+                Self::PrevBssid(payload.try_into().map_err(|_| {
+                    format!(
+                        "Invalid length of NL80211_ATTR_PREV_BSSID, \
+                        expected length {ETH_ALEN} got {payload:?}"
+                    )
+                })?)
+            }
+            NL80211_ATTR_PMKID => {
+                // WLAN_PMKID_LEN is 16 octets (802.11-2020 §9.4.2.25.3).
+                const PMKID_LEN: usize = 16;
+                if payload.len() != PMKID_LEN {
+                    return Err(format!(
+                        "Invalid length of NL80211_ATTR_PMKID, \
+                        expected length {PMKID_LEN} got {payload:?}"
+                    )
+                    .into());
+                }
+                Self::Pmkid(payload.to_vec())
+            }
+            NL80211_ATTR_PMK => Self::Pmk(payload.to_vec()),
+            NL80211_ATTR_PMK_LIFETIME => {
+                let err_msg = format!(
+                    "Invalid NL80211_ATTR_PMK_LIFETIME value {payload:?}"
+                );
+                Self::PmkLifetime(parse_u32(payload).context(err_msg)?)
+            }
+            NL80211_ATTR_PMK_REAUTH_THRESHOLD => {
+                let err_msg = format!(
+                    "Invalid NL80211_ATTR_PMK_REAUTH_THRESHOLD value \
+                    {payload:?}"
+                );
+                Self::PmkReauthThreshold(parse_u8(payload).context(err_msg)?)
             }
             NL80211_ATTR_EXTERNAL_AUTH_ACTION => {
                 let err_msg = format!(

--- a/src/connect/assoc.rs
+++ b/src/connect/assoc.rs
@@ -31,6 +31,14 @@ impl Nl80211AttrsBuilder<Nl80211Associate> {
         self.replace(Nl80211Attr::Mac(mac))
     }
 
+    /// BSSID of the AP the station is currently associated with. Setting
+    /// this turns the request into a reassociation (802.11-2020 §11.3.3),
+    /// e.g. for roaming (including Fast BSS Transition) to a new BSSID
+    /// within the same ESS.
+    pub fn prev_bssid(self, mac: [u8; 6]) -> Self {
+        self.replace(Nl80211Attr::PrevBssid(mac))
+    }
+
     /// Channel frequency hint in MHz.
     pub fn frequency(self, freq_mhz: u32) -> Self {
         self.replace(Nl80211Attr::WiphyFreq(freq_mhz))

--- a/src/connect/auth.rs
+++ b/src/connect/auth.rs
@@ -45,9 +45,19 @@ impl Nl80211AttrsBuilder<Nl80211Authenticate> {
     }
 
     /// Authentication data, e.g. the SAE commit or confirm body
-    /// (`transaction || status || body`).
+    /// (`transaction || status || body`). Only valid for the SAE, FILS,
+    /// EPPKE and IEEE 802.1X auth types.
     pub fn auth_data(self, auth_data: Vec<u8>) -> Self {
         self.replace(Nl80211Attr::AuthData(auth_data))
+    }
+
+    /// Information elements for the authentication frame body, used with
+    /// [`Nl80211AuthType::Ft`] (Fast BSS Transition over the air): the
+    /// kernel transmits them after the fixed authentication fields
+    /// (algorithm / transaction / status). `NL80211_ATTR_AUTH_DATA` is
+    /// rejected by the kernel for FT authentication.
+    pub fn ie(self, ie: Vec<u8>) -> Self {
+        self.replace(Nl80211Attr::Ie(ie))
     }
 }
 

--- a/src/connect/handle.rs
+++ b/src/connect/handle.rs
@@ -3,9 +3,10 @@
 use crate::{
     Nl80211AssociateRequest, Nl80211Attr, Nl80211AuthenticateRequest,
     Nl80211ConnectRequest, Nl80211ControlPortFrameRequest,
-    Nl80211DisconnectRequest, Nl80211ExternalAuthRequest, Nl80211FrameRequest,
+    Nl80211DelPmkRequest, Nl80211DelPmksaRequest, Nl80211DisconnectRequest,
+    Nl80211ExternalAuthRequest, Nl80211FlushPmksaRequest, Nl80211FrameRequest,
     Nl80211Handle, Nl80211KeyRequest, Nl80211RegisterFrameRequest,
-    Nl80211RekeyOffloadRequest,
+    Nl80211RekeyOffloadRequest, Nl80211SetPmkRequest, Nl80211SetPmksaRequest,
 };
 
 /// A handle to send connection management commands (`NL80211_CMD_CONNECT` and
@@ -144,5 +145,58 @@ impl Nl80211ConnectionHandle {
         attributes: Vec<Nl80211Attr>,
     ) -> Nl80211RekeyOffloadRequest {
         Nl80211RekeyOffloadRequest::new(self.0.clone(), attributes)
+    }
+
+    /// Add a PMKSA cache entry to the driver/firmware
+    /// (`NL80211_CMD_SET_PMKSA`), so the driver can skip full
+    /// authentication on reconnects / roaming.
+    ///
+    /// The `attributes` are normally produced by [`crate::Nl80211Pmksa`].
+    /// Fails with `-EOPNOTSUPP` on drivers without a `set_pmksa` op.
+    pub fn set_pmksa(
+        &mut self,
+        attributes: Vec<Nl80211Attr>,
+    ) -> Nl80211SetPmksaRequest {
+        Nl80211SetPmksaRequest::new(self.0.clone(), attributes)
+    }
+
+    /// Delete a driver/firmware PMKSA cache entry
+    /// (`NL80211_CMD_DEL_PMKSA`).
+    ///
+    /// The `attributes` are normally produced by [`crate::Nl80211Pmksa`].
+    pub fn del_pmksa(
+        &mut self,
+        attributes: Vec<Nl80211Attr>,
+    ) -> Nl80211DelPmksaRequest {
+        Nl80211DelPmksaRequest::new(self.0.clone(), attributes)
+    }
+
+    /// Delete every driver/firmware PMKSA cache entry of the interface
+    /// (`NL80211_CMD_FLUSH_PMKSA`).
+    pub fn flush_pmksa(
+        &mut self,
+        attributes: Vec<Nl80211Attr>,
+    ) -> Nl80211FlushPmksaRequest {
+        Nl80211FlushPmksaRequest::new(self.0.clone(), attributes)
+    }
+
+    /// Hand the PMK (or PMK-R0) to the driver for offloaded key
+    /// management (`NL80211_CMD_SET_PMK`).
+    ///
+    /// The `attributes` are normally produced by [`crate::Nl80211Pmk`].
+    pub fn set_pmk(
+        &mut self,
+        attributes: Vec<Nl80211Attr>,
+    ) -> Nl80211SetPmkRequest {
+        Nl80211SetPmkRequest::new(self.0.clone(), attributes)
+    }
+
+    /// Clear the PMK previously handed to the driver via
+    /// [`Self::set_pmk`] (`NL80211_CMD_DEL_PMK`).
+    pub fn del_pmk(
+        &mut self,
+        attributes: Vec<Nl80211Attr>,
+    ) -> Nl80211DelPmkRequest {
+        Nl80211DelPmkRequest::new(self.0.clone(), attributes)
     }
 }

--- a/src/connect/mod.rs
+++ b/src/connect/mod.rs
@@ -6,6 +6,7 @@ mod disconnect;
 mod external_auth;
 mod frame;
 mod handle;
+mod pmksa;
 mod request;
 mod types;
 
@@ -20,6 +21,10 @@ pub use self::frame::{
     Nl80211FrameRequest, Nl80211RegisterFrame, Nl80211RegisterFrameRequest,
 };
 pub use self::handle::Nl80211ConnectionHandle;
+pub use self::pmksa::{
+    Nl80211DelPmkRequest, Nl80211DelPmksaRequest, Nl80211FlushPmksaRequest,
+    Nl80211Pmk, Nl80211Pmksa, Nl80211SetPmkRequest, Nl80211SetPmksaRequest,
+};
 pub use self::request::{Nl80211Connect, Nl80211ConnectRequest};
 pub use self::types::{
     Nl80211AuthType, Nl80211ExternalAuthAction, Nl80211UseMfp,

--- a/src/connect/pmksa.rs
+++ b/src/connect/pmksa.rs
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: MIT
+
+use futures::TryStream;
+use netlink_packet_core::{NLM_F_ACK, NLM_F_REQUEST};
+use netlink_packet_generic::GenlMessage;
+
+use crate::{
+    nl80211_execute, Nl80211Attr, Nl80211AttrsBuilder, Nl80211Command,
+    Nl80211Error, Nl80211Handle, Nl80211Message,
+};
+
+/// Helper to build the attribute list for the driver PMKSA cache commands
+/// `NL80211_CMD_SET_PMKSA` and `NL80211_CMD_DEL_PMKSA`.
+///
+/// The kernel requires [`pmkid`](Nl80211AttrsBuilder::<Nl80211Pmksa>::pmkid)
+/// and the BSSID via [`mac`](Nl80211AttrsBuilder::<Nl80211Pmksa>::mac);
+/// `SET_PMKSA` additionally takes the PMK material and (optionally) the
+/// lifetime / reauthentication threshold.
+#[derive(Debug)]
+pub struct Nl80211Pmksa;
+
+impl Nl80211Pmksa {
+    /// Start building a PMKSA cache request for the interface `if_index`.
+    pub fn new(if_index: u32) -> Nl80211AttrsBuilder<Self> {
+        Nl80211AttrsBuilder::<Self>::new().if_index(if_index)
+    }
+}
+
+impl Nl80211AttrsBuilder<Nl80211Pmksa> {
+    /// The 16-octet PMKID of the cache entry.
+    pub fn pmkid(self, pmkid: Vec<u8>) -> Self {
+        self.replace(Nl80211Attr::Pmkid(pmkid))
+    }
+
+    /// BSSID of the AP the PMKSA cache entry belongs to.
+    pub fn mac(self, mac: [u8; 6]) -> Self {
+        self.replace(Nl80211Attr::Mac(mac))
+    }
+
+    /// The PMK belonging to the cache entry.
+    pub fn pmk(self, pmk: Vec<u8>) -> Self {
+        self.replace(Nl80211Attr::Pmk(pmk))
+    }
+
+    /// Maximum lifetime of the cache entry in seconds
+    /// (`NL80211_ATTR_PMK_LIFETIME`).
+    pub fn pmk_lifetime(self, seconds: u32) -> Self {
+        self.replace(Nl80211Attr::PmkLifetime(seconds))
+    }
+
+    /// Reauthentication threshold in percent of the lifetime
+    /// (`NL80211_ATTR_PMK_REAUTH_THRESHOLD`).
+    pub fn pmk_reauth_threshold(self, percent: u8) -> Self {
+        self.replace(Nl80211Attr::PmkReauthThreshold(percent))
+    }
+}
+
+pub struct Nl80211SetPmksaRequest {
+    handle: Nl80211Handle,
+    attributes: Vec<Nl80211Attr>,
+}
+
+impl Nl80211SetPmksaRequest {
+    pub(crate) fn new(
+        handle: Nl80211Handle,
+        attributes: Vec<Nl80211Attr>,
+    ) -> Self {
+        Nl80211SetPmksaRequest { handle, attributes }
+    }
+
+    /// Send the `NL80211_CMD_SET_PMKSA` request.
+    ///
+    /// Fails with `-EOPNOTSUPP` when the driver has no `set_pmksa` op
+    /// (e.g. mac80211-based drivers without AP-side PMKSA caching).
+    pub async fn execute(
+        self,
+    ) -> impl TryStream<Ok = GenlMessage<Nl80211Message>, Error = Nl80211Error>
+    {
+        let Nl80211SetPmksaRequest {
+            mut handle,
+            attributes,
+        } = self;
+        let nl80211_msg = Nl80211Message {
+            cmd: Nl80211Command::SetPmksa,
+            attributes,
+        };
+        nl80211_execute(&mut handle, nl80211_msg, NLM_F_REQUEST | NLM_F_ACK)
+            .await
+    }
+}
+
+pub struct Nl80211DelPmksaRequest {
+    handle: Nl80211Handle,
+    attributes: Vec<Nl80211Attr>,
+}
+
+impl Nl80211DelPmksaRequest {
+    pub(crate) fn new(
+        handle: Nl80211Handle,
+        attributes: Vec<Nl80211Attr>,
+    ) -> Self {
+        Nl80211DelPmksaRequest { handle, attributes }
+    }
+
+    /// Send the `NL80211_CMD_DEL_PMKSA` request.
+    pub async fn execute(
+        self,
+    ) -> impl TryStream<Ok = GenlMessage<Nl80211Message>, Error = Nl80211Error>
+    {
+        let Nl80211DelPmksaRequest {
+            mut handle,
+            attributes,
+        } = self;
+        let nl80211_msg = Nl80211Message {
+            cmd: Nl80211Command::DelPmksa,
+            attributes,
+        };
+        nl80211_execute(&mut handle, nl80211_msg, NLM_F_REQUEST | NLM_F_ACK)
+            .await
+    }
+}
+
+pub struct Nl80211FlushPmksaRequest {
+    handle: Nl80211Handle,
+    attributes: Vec<Nl80211Attr>,
+}
+
+impl Nl80211FlushPmksaRequest {
+    pub(crate) fn new(
+        handle: Nl80211Handle,
+        attributes: Vec<Nl80211Attr>,
+    ) -> Self {
+        Nl80211FlushPmksaRequest { handle, attributes }
+    }
+
+    /// Send the `NL80211_CMD_FLUSH_PMKSA` request (drop every driver
+    /// PMKSA cache entry of the interface).
+    pub async fn execute(
+        self,
+    ) -> impl TryStream<Ok = GenlMessage<Nl80211Message>, Error = Nl80211Error>
+    {
+        let Nl80211FlushPmksaRequest {
+            mut handle,
+            attributes,
+        } = self;
+        let nl80211_msg = Nl80211Message {
+            cmd: Nl80211Command::FlushPmksa,
+            attributes,
+        };
+        nl80211_execute(&mut handle, nl80211_msg, NLM_F_REQUEST | NLM_F_ACK)
+            .await
+    }
+}
+
+/// Helper to build the attribute list for the offloaded-PMK commands
+/// `NL80211_CMD_SET_PMK` / `NL80211_CMD_DEL_PMK` (hand the PMK / PMK-R0 to
+/// the driver for offloaded 4-way handshake or offloaded Fast BSS
+/// Transition).
+#[derive(Debug)]
+pub struct Nl80211Pmk;
+
+impl Nl80211Pmk {
+    /// Start building a PMK request for the interface `if_index`.
+    pub fn new(if_index: u32) -> Nl80211AttrsBuilder<Self> {
+        Nl80211AttrsBuilder::<Self>::new().if_index(if_index)
+    }
+}
+
+impl Nl80211AttrsBuilder<Nl80211Pmk> {
+    /// The PMK (or PMK-R0) material handed to the driver.
+    pub fn pmk(self, pmk: Vec<u8>) -> Self {
+        self.replace(Nl80211Attr::Pmk(pmk))
+    }
+}
+
+pub struct Nl80211SetPmkRequest {
+    handle: Nl80211Handle,
+    attributes: Vec<Nl80211Attr>,
+}
+
+impl Nl80211SetPmkRequest {
+    pub(crate) fn new(
+        handle: Nl80211Handle,
+        attributes: Vec<Nl80211Attr>,
+    ) -> Self {
+        Nl80211SetPmkRequest { handle, attributes }
+    }
+
+    /// Send the `NL80211_CMD_SET_PMK` request.
+    pub async fn execute(
+        self,
+    ) -> impl TryStream<Ok = GenlMessage<Nl80211Message>, Error = Nl80211Error>
+    {
+        let Nl80211SetPmkRequest {
+            mut handle,
+            attributes,
+        } = self;
+        let nl80211_msg = Nl80211Message {
+            cmd: Nl80211Command::SetPmk,
+            attributes,
+        };
+        nl80211_execute(&mut handle, nl80211_msg, NLM_F_REQUEST | NLM_F_ACK)
+            .await
+    }
+}
+
+pub struct Nl80211DelPmkRequest {
+    handle: Nl80211Handle,
+    attributes: Vec<Nl80211Attr>,
+}
+
+impl Nl80211DelPmkRequest {
+    pub(crate) fn new(
+        handle: Nl80211Handle,
+        attributes: Vec<Nl80211Attr>,
+    ) -> Self {
+        Nl80211DelPmkRequest { handle, attributes }
+    }
+
+    /// Send the `NL80211_CMD_DEL_PMK` request (clear the PMK previously
+    /// set via [`Nl80211SetPmkRequest`]).
+    pub async fn execute(
+        self,
+    ) -> impl TryStream<Ok = GenlMessage<Nl80211Message>, Error = Nl80211Error>
+    {
+        let Nl80211DelPmkRequest {
+            mut handle,
+            attributes,
+        } = self;
+        let nl80211_msg = Nl80211Message {
+            cmd: Nl80211Command::DelPmk,
+            attributes,
+        };
+        nl80211_execute(&mut handle, nl80211_msg, NLM_F_REQUEST | NLM_F_ACK)
+            .await
+    }
+}

--- a/src/key_request.rs
+++ b/src/key_request.rs
@@ -31,6 +31,7 @@ impl Nl80211Key {
             cipher: Nl80211CipherSuite::Ccmp128,
             seq: None,
             key_type: None,
+            default_mgmt: false,
             default_types: Vec::new(),
         }
     }
@@ -62,6 +63,44 @@ impl Nl80211Key {
             .key_type(Nl80211KeyType::Group)
             .default_types(vec![Nl80211KeyDefaultType::Multicast])
     }
+
+    /// Convenience for installing an Integrity GTK (IEEE 802.11w / PMF):
+    /// BIP-CMAC-128 at `key_index` (4-5, as assigned by the AP), with `seq`
+    /// holding the 6-octet IPN (receive sequence counter) from the IGTK KDE,
+    /// marked as the default management-frame key
+    /// (`NL80211_KEY_DEFAULT_MGMT`).
+    pub fn new_igtk(
+        if_index: u32,
+        key_data: Vec<u8>,
+        key_index: u8,
+        seq: Vec<u8>,
+    ) -> Nl80211KeyRequestBuilder {
+        Self::new(if_index)
+            .key_data(key_data)
+            .key_index(key_index)
+            .cipher(Nl80211CipherSuite::BipCmac128)
+            .seq(seq)
+            .key_type(Nl80211KeyType::Group)
+            .default_mgmt(true)
+    }
+
+    /// Convenience for installing a Beacon Integrity GTK (IEEE 802.11w-2024
+    /// beacon protection): BIP-CMAC-128 at `key_index` (6-7), with `seq`
+    /// holding the 6-octet IPN from the BIGTK KDE. The BIGTK is RX-only
+    /// (beacon protection) and never the default TX management key.
+    pub fn new_bigtk(
+        if_index: u32,
+        key_data: Vec<u8>,
+        key_index: u8,
+        seq: Vec<u8>,
+    ) -> Nl80211KeyRequestBuilder {
+        Self::new(if_index)
+            .key_data(key_data)
+            .key_index(key_index)
+            .cipher(Nl80211CipherSuite::BipCmac128)
+            .seq(seq)
+            .key_type(Nl80211KeyType::Group)
+    }
 }
 
 /// Builder for the attributes of a `NL80211_CMD_NEW_KEY` request.
@@ -74,6 +113,7 @@ pub struct Nl80211KeyRequestBuilder {
     cipher: Nl80211CipherSuite,
     seq: Option<Vec<u8>>,
     key_type: Option<Nl80211KeyType>,
+    default_mgmt: bool,
     default_types: Vec<Nl80211KeyDefaultType>,
 }
 
@@ -114,6 +154,13 @@ impl Nl80211KeyRequestBuilder {
         self
     }
 
+    /// Mark the key as the default management-frame (BIP) key
+    /// (`NL80211_KEY_DEFAULT_MGMT`), used when installing the IGTK.
+    pub fn default_mgmt(mut self, enable: bool) -> Self {
+        self.default_mgmt = enable;
+        self
+    }
+
     /// Traffic types this key is the default for.
     pub fn default_types(
         mut self,
@@ -140,6 +187,9 @@ impl Nl80211KeyRequestBuilder {
         key.push(Nl80211KeyAttr::Idx(self.key_index));
         if let Some(key_type) = self.key_type {
             key.push(Nl80211KeyAttr::Type(key_type));
+        }
+        if self.default_mgmt {
+            key.push(Nl80211KeyAttr::DefaultMgmt);
         }
         if !self.default_types.is_empty() {
             key.push(Nl80211KeyAttr::DefaultTypes(self.default_types));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,10 +50,12 @@ pub use self::connect::{
     Nl80211Associate, Nl80211AssociateRequest, Nl80211AuthType,
     Nl80211Authenticate, Nl80211AuthenticateRequest, Nl80211Connect,
     Nl80211ConnectRequest, Nl80211ConnectionHandle, Nl80211ControlPortFrame,
-    Nl80211ControlPortFrameRequest, Nl80211Disconnect,
-    Nl80211DisconnectRequest, Nl80211ExternalAuth, Nl80211ExternalAuthAction,
-    Nl80211ExternalAuthRequest, Nl80211Frame, Nl80211FrameRequest,
-    Nl80211RegisterFrame, Nl80211RegisterFrameRequest, Nl80211UseMfp,
+    Nl80211ControlPortFrameRequest, Nl80211DelPmkRequest,
+    Nl80211DelPmksaRequest, Nl80211Disconnect, Nl80211DisconnectRequest,
+    Nl80211ExternalAuth, Nl80211ExternalAuthAction, Nl80211ExternalAuthRequest,
+    Nl80211FlushPmksaRequest, Nl80211Frame, Nl80211FrameRequest, Nl80211Pmk,
+    Nl80211Pmksa, Nl80211RegisterFrame, Nl80211RegisterFrameRequest,
+    Nl80211SetPmkRequest, Nl80211SetPmksaRequest, Nl80211UseMfp,
     Nl80211WpaVersions,
 };
 #[cfg(feature = "tokio_socket")]

--- a/src/tests/key.rs
+++ b/src/tests/key.rs
@@ -274,3 +274,48 @@ fn test_new_key_conveniences() {
         parse_message_attributes(&gtk)
     );
 }
+
+// The IGTK convenience installs BIP-CMAC-128 (00-0f-ac:6) at the AP-assigned
+// index (4-5) with the IPN as KEY_SEQ and the NL80211_KEY_DEFAULT_MGMT flag.
+#[test]
+fn test_new_key_igtk_convenience() {
+    let igtk = emit_new_key_attributes(
+        Nl80211Key::new_igtk(464, vec![0xcc; 16], 4, vec![0x01; 6]).build(),
+    );
+    assert_eq!(
+        vec![
+            Nl80211Attr::IfIndex(464),
+            Nl80211Attr::Key(vec![
+                Nl80211KeyAttr::Data(vec![0xcc; 16]),
+                Nl80211KeyAttr::Cipher(0x000F_AC06),
+                Nl80211KeyAttr::Seq(vec![0x01; 6]),
+                Nl80211KeyAttr::Idx(4),
+                Nl80211KeyAttr::Type(Nl80211KeyType::Group),
+                Nl80211KeyAttr::DefaultMgmt,
+            ]),
+        ],
+        parse_message_attributes(&igtk)
+    );
+}
+
+// The BIGTK convenience installs BIP-CMAC-128 at index 6-7 without the
+// default-management flag (beacon protection is RX-only).
+#[test]
+fn test_new_key_bigtk_convenience() {
+    let bigtk = emit_new_key_attributes(
+        Nl80211Key::new_bigtk(464, vec![0xdd; 16], 6, vec![0x02; 6]).build(),
+    );
+    assert_eq!(
+        vec![
+            Nl80211Attr::IfIndex(464),
+            Nl80211Attr::Key(vec![
+                Nl80211KeyAttr::Data(vec![0xdd; 16]),
+                Nl80211KeyAttr::Cipher(0x000F_AC06),
+                Nl80211KeyAttr::Seq(vec![0x02; 6]),
+                Nl80211KeyAttr::Idx(6),
+                Nl80211KeyAttr::Type(Nl80211KeyType::Group),
+            ]),
+        ],
+        parse_message_attributes(&bigtk)
+    );
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -7,4 +7,5 @@ mod disconnect;
 mod event;
 mod key;
 mod register_frame;
+mod roaming;
 mod scan;

--- a/src/tests/roaming.rs
+++ b/src/tests/roaming.rs
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: MIT
+
+// Round-trip and builder tests for the roaming-related attributes
+// (`NL80211_ATTR_PREV_BSSID`, `NL80211_ATTR_PMKID`, `NL80211_ATTR_PMK`,
+// `NL80211_ATTR_PMK_LIFETIME`, `NL80211_ATTR_PMK_REAUTH_THRESHOLD`) and the
+// `NL80211_CMD_{SET,DEL,FLUSH}_PMKSA` / `NL80211_CMD_{SET,DEL}_PMK` request
+// builders. The raw blobs are hand-built netlink attributes (length, type,
+// value) padded to the 4-byte netlink alignment, mirroring the kernel's
+// `nla_put` wire format.
+
+use netlink_packet_core::{Emitable, NlaBuffer, NlasIterator, Parseable};
+
+use crate::{
+    Nl80211Associate, Nl80211Attr, Nl80211Command, Nl80211Message, Nl80211Pmk,
+    Nl80211Pmksa,
+};
+
+fn assert_roundtrip(expected: Nl80211Attr, raw: Vec<u8>) {
+    assert_eq!(
+        expected,
+        Nl80211Attr::parse(&NlaBuffer::new_checked(&raw).unwrap()).unwrap()
+    );
+    let mut buf = vec![0; expected.buffer_len()];
+    expected.emit(&mut buf);
+    assert_eq!(buf, raw);
+}
+
+// NL80211_ATTR_PREV_BSSID (79): the BSSID of the current AP, turning
+// NL80211_CMD_ASSOCIATE into a reassociation.
+#[test]
+fn test_prev_bssid_roundtrip() {
+    let raw = vec![
+        0x0a, 0x00, 0x4f, 0x00, 0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+    ];
+    assert_roundtrip(
+        Nl80211Attr::PrevBssid([0x02, 0x00, 0x00, 0x00, 0x01, 0x00]),
+        raw,
+    );
+}
+
+// NL80211_ATTR_PREV_BSSID with an invalid length must be rejected.
+#[test]
+fn test_prev_bssid_invalid_len() {
+    let raw = vec![0x08, 0x00, 0x4f, 0x00, 0x02, 0x00, 0x00, 0x00];
+    assert!(Nl80211Attr::parse(&NlaBuffer::new_checked(&raw).unwrap()).is_err());
+}
+
+// NL80211_ATTR_PMKID (85): a 16-octet PMKID.
+#[test]
+fn test_pmkid_roundtrip() {
+    let mut raw = vec![0x14, 0x00, 0x55, 0x00];
+    raw.extend_from_slice(&[0x42; 16]);
+    assert_roundtrip(Nl80211Attr::Pmkid(vec![0x42; 16]), raw);
+}
+
+// A PMKID of any length other than WLAN_PMKID_LEN (16) must be rejected.
+#[test]
+fn test_pmkid_invalid_len() {
+    let mut raw = vec![0x0c, 0x00, 0x55, 0x00];
+    raw.extend_from_slice(&[0x42; 8]);
+    assert!(Nl80211Attr::parse(&NlaBuffer::new_checked(&raw).unwrap()).is_err());
+}
+
+// NL80211_ATTR_PMK (254): the PMK material (32 octets for the PSK/SAE
+// AKMs).
+#[test]
+fn test_pmk_roundtrip() {
+    let mut raw = vec![0x24, 0x00, 0xfe, 0x00];
+    raw.extend_from_slice(&[0x77; 32]);
+    assert_roundtrip(Nl80211Attr::Pmk(vec![0x77; 32]), raw);
+}
+
+// NL80211_ATTR_PMK_LIFETIME (287): u32 seconds.
+#[test]
+fn test_pmk_lifetime_roundtrip() {
+    let raw = vec![0x08, 0x00, 0x1f, 0x01, 0x80, 0xa8, 0x00, 0x00];
+    assert_roundtrip(Nl80211Attr::PmkLifetime(43136), raw);
+}
+
+// NL80211_ATTR_PMK_REAUTH_THRESHOLD (288): u8 percent, padded to the
+// 4-byte alignment.
+#[test]
+fn test_pmk_reauth_threshold_roundtrip() {
+    let raw = vec![0x05, 0x00, 0x20, 0x01, 0x46, 0x00, 0x00, 0x00];
+    assert_roundtrip(Nl80211Attr::PmkReauthThreshold(70), raw);
+}
+
+fn emit_message_attributes(
+    cmd: Nl80211Command,
+    attributes: Vec<Nl80211Attr>,
+) -> Vec<u8> {
+    let msg = Nl80211Message { cmd, attributes };
+    let mut buf = vec![0u8; msg.buffer_len()];
+    msg.emit(&mut buf);
+    buf
+}
+
+fn parse_message_attributes(raw: &[u8]) -> Vec<Nl80211Attr> {
+    NlasIterator::new(raw)
+        .map(|nla| Nl80211Attr::parse(&nla.unwrap()).unwrap())
+        .collect()
+}
+
+// The association request of a reassociation carries the new BSSID in
+// NL80211_ATTR_MAC and the current one in NL80211_ATTR_PREV_BSSID.
+#[test]
+fn test_associate_prev_bssid() {
+    let buf = emit_message_attributes(
+        Nl80211Command::Associate,
+        Nl80211Associate::new(3)
+            .mac([0x02, 0x00, 0x00, 0x00, 0x02, 0x00])
+            .prev_bssid([0x02, 0x00, 0x00, 0x00, 0x01, 0x00])
+            .build(),
+    );
+    assert_eq!(
+        vec![
+            Nl80211Attr::IfIndex(3),
+            Nl80211Attr::Mac([0x02, 0x00, 0x00, 0x00, 0x02, 0x00]),
+            Nl80211Attr::PrevBssid([0x02, 0x00, 0x00, 0x00, 0x01, 0x00]),
+        ],
+        parse_message_attributes(&buf)
+    );
+}
+
+// NL80211_CMD_SET_PMKSA carries PMKID + MAC (BSSID) + PMK (the kernel's
+// nl80211_set_pmksa requires PMKID and MAC; PMK is the cache content).
+#[test]
+fn test_set_pmksa_builder() {
+    let buf = emit_message_attributes(
+        Nl80211Command::SetPmksa,
+        Nl80211Pmksa::new(3)
+            .pmkid(vec![0x11; 16])
+            .mac([0x02, 0x00, 0x00, 0x00, 0x01, 0x00])
+            .pmk(vec![0x22; 32])
+            .pmk_lifetime(43200)
+            .pmk_reauth_threshold(70)
+            .build(),
+    );
+    // The builder emits attributes sorted by their netlink kind.
+    assert_eq!(
+        vec![
+            Nl80211Attr::IfIndex(3),
+            Nl80211Attr::Mac([0x02, 0x00, 0x00, 0x00, 0x01, 0x00]),
+            Nl80211Attr::Pmkid(vec![0x11; 16]),
+            Nl80211Attr::Pmk(vec![0x22; 32]),
+            Nl80211Attr::PmkLifetime(43200),
+            Nl80211Attr::PmkReauthThreshold(70),
+        ],
+        parse_message_attributes(&buf)
+    );
+}
+
+// NL80211_CMD_DEL_PMKSA only needs PMKID + MAC.
+#[test]
+fn test_del_pmksa_builder() {
+    let buf = emit_message_attributes(
+        Nl80211Command::DelPmksa,
+        Nl80211Pmksa::new(3)
+            .pmkid(vec![0x11; 16])
+            .mac([0x02, 0x00, 0x00, 0x00, 0x01, 0x00])
+            .build(),
+    );
+    assert_eq!(
+        vec![
+            Nl80211Attr::IfIndex(3),
+            Nl80211Attr::Mac([0x02, 0x00, 0x00, 0x00, 0x01, 0x00]),
+            Nl80211Attr::Pmkid(vec![0x11; 16]),
+        ],
+        parse_message_attributes(&buf)
+    );
+}
+
+// NL80211_CMD_SET_PMK carries just the PMK material.
+#[test]
+fn test_set_pmk_builder() {
+    let buf = emit_message_attributes(
+        Nl80211Command::SetPmk,
+        Nl80211Pmk::new(3).pmk(vec![0x33; 32]).build(),
+    );
+    assert_eq!(
+        vec![Nl80211Attr::IfIndex(3), Nl80211Attr::Pmk(vec![0x33; 32])],
+        parse_message_attributes(&buf)
+    );
+}


### PR DESCRIPTION
Introduced support for the netlink pieces needed by station roaming:
 - New attributes: `NL80211_ATTR_PREV_BSSID` (reassociation),
   `NL80211_ATTR_PMKID`, `NL80211_ATTR_PMK`,
   `NL80211_ATTR_PMK_LIFETIME` and
   `NL80211_ATTR_PMK_REAUTH_THRESHOLD`.
 - `Nl80211Associate`: new `prev_bssid()` method to turn an
   association into a reassociation (roam).
 - `Nl80211Key`: new `new_igtk()`/`new_bigtk()` conveniences and a
   `default_mgmt()` method for PMF management keys.
 - New `Nl80211Pmksa`/`Nl80211Pmk` builders with `set_pmksa()`,
   `del_pmksa()`, `flush_pmksa()`, `set_pmk()` and `del_pmk()`
   methods on `Nl80211ConnectionHandle`.

Include unit test cases.