### PR TITLE
fix: parse (re)association response status code from the IEEE frame

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -3,10 +3,10 @@
 use genetlink::message::RawGenlMessage;
 use netlink_packet_core::{NetlinkMessage, NetlinkPayload};
 
-use crate::event_status::{Nl80211EventCode, Nl80211EventReason};
+use crate::event_status::{Ieee80211ReasonCode, Ieee80211StatusCode};
 use crate::{
-    Nl80211Attr, Nl80211AuthFrame, Nl80211Command, Nl80211Message,
-    Nl80211WowlanTriggersSupport, Nl80211WowlanWakeup,
+    Ieee80211AssocRespFrame, Ieee80211AuthFrame, Nl80211Attr, Nl80211Command,
+    Nl80211Message, Nl80211WowlanTriggersSupport, Nl80211WowlanWakeup,
 };
 
 /// A multicast nl80211 event received from the kernel, e.g. on the `mlme`,
@@ -15,31 +15,31 @@ use crate::{
 #[non_exhaustive]
 pub enum Nl80211Event {
     /// `NL80211_CMD_AUTHENTICATE` event: the authentication result. `status`
-    /// is [`Nl80211EventCode`]; `frame` is the full 802.11 authentication
+    /// is [`Ieee80211StatusCode`]; `frame` is the full 802.11 authentication
     /// frame when the kernel delivered one (SAE exchanges).
     Authenticated {
-        status: Nl80211EventCode,
+        status: Ieee80211StatusCode,
         frame: Option<Vec<u8>>,
     },
     /// `NL80211_CMD_ASSOCIATE` event: the association result. `ies` are the
     /// information elements from the Association Response frame (they carry
     /// e.g. the AP's OWE DH Parameter Element for OWE networks).
     Associated {
-        status: Nl80211EventCode,
+        status: Ieee80211StatusCode,
         ies: Option<Vec<u8>>,
     },
     /// `NL80211_CMD_CONNECT` event: the connection result.
-    ConnectResult { status: Nl80211EventCode },
+    ConnectResult { status: Ieee80211StatusCode },
     /// `NL80211_CMD_DISCONNECT` event: the IEEE 802.11 reason code.
-    Disconnect { reason: Nl80211EventReason },
+    Disconnect { reason: Ieee80211ReasonCode },
     /// `NL80211_CMD_DEAUTHENTICATE` event: the AP deauthenticated the STA;
     /// `reason` is the IEEE 802.11 reason code (e.g. 2
     /// `PrevAuthNotValid` / 23 `Ieee8021xFailed` indicate a fatal
     /// credential problem, anything else is transient).
-    Deauthenticated { reason: Nl80211EventReason },
+    Deauthenticated { reason: Ieee80211ReasonCode },
     /// `NL80211_CMD_DISASSOCIATE` event: the AP disassociated the STA;
     /// `reason` is the IEEE 802.11 reason code.
-    Disassociated { reason: Nl80211EventReason },
+    Disassociated { reason: Ieee80211ReasonCode },
     /// `NL80211_CMD_FRAME` event: a received management frame the socket
     /// registered for.
     Frame { frame: Vec<u8> },
@@ -190,10 +190,10 @@ fn attr_reason(msg: &Nl80211Message) -> u16 {
 /// `NL80211_ATTR_FRAME` and no `NL80211_ATTR_REASON_CODE`; the reason
 /// code sits at offset 24-25 of the frame (after the 24-byte 802.11
 /// header).
-fn attr_frame_reason(msg: &Nl80211Message) -> Option<Nl80211EventReason> {
+fn attr_frame_reason(msg: &Nl80211Message) -> Option<Ieee80211ReasonCode> {
     msg.attributes.iter().find_map(|attr| match attr {
         Nl80211Attr::Frame(frame) if frame.len() >= 26 => {
-            Some(Nl80211EventReason::from(u16::from_le_bytes([
+            Some(Ieee80211ReasonCode::from(u16::from_le_bytes([
                 frame[24], frame[25],
             ])))
         }
@@ -267,16 +267,16 @@ fn attr_ie(msg: &Nl80211Message) -> Option<Vec<u8>> {
 }
 
 fn parse_authenticate(msg: &Nl80211Message) -> Nl80211Event {
-    let mut status = Nl80211EventCode::from(attr_status(msg));
+    let mut status = Ieee80211StatusCode::from(attr_status(msg));
     let frame = attr_frame(msg);
 
     // The kernel may deliver the authentication result without a
     // NL80211_ATTR_STATUS_CODE, relying on the status code inside the
     // 802.11 authentication frame.
-    if status == Nl80211EventCode::Success {
+    if status == Ieee80211StatusCode::Success {
         if let Some(ref frame) = frame {
-            if let Ok(auth_frame) = Nl80211AuthFrame::parse(frame) {
-                status = auth_frame.status;
+            if let Ok(auth_frame) = Ieee80211AuthFrame::parse(frame) {
+                status = auth_frame.status_code;
             }
         }
     }
@@ -285,22 +285,30 @@ fn parse_authenticate(msg: &Nl80211Message) -> Nl80211Event {
 }
 
 fn parse_associate(msg: &Nl80211Message) -> Nl80211Event {
-    let status = attr_status(msg);
-    let mut ies = attr_ie(msg);
+    // mac80211/cfg80211 deliver the (Re)Association Response as a full
+    // management frame in NL80211_ATTR_FRAME, without
+    // NL80211_ATTR_STATUS_CODE. Parse the standard frame layout for the
+    // status code and the response IEs.
+    let assoc_frame = attr_frame(msg)
+        .and_then(|frame| Ieee80211AssocRespFrame::parse(&frame).ok());
 
-    // When the kernel omits NL80211_ATTR_IE, the IEs are inside the full
-    // association response frame, starting after the 24-byte 802.11 header +
-    // capability(2) + status(2) + AID(2) = offset 30.
-    if ies.is_none() {
-        if let Some(frame) = attr_frame(msg) {
-            if frame.len() > 30 {
-                ies = Some(frame[30..].to_vec());
-            }
-        }
-    }
+    let status = assoc_frame
+        .as_ref()
+        .map(|frame| frame.status_code)
+        .or_else(|| {
+            msg.attributes.iter().find_map(|attr| match attr {
+                Nl80211Attr::StatusCode(code) => Some((*code).into()),
+                _ => None,
+            })
+        })
+        .unwrap_or(Ieee80211StatusCode::Success);
+    // The parsed frame body keeps AID(2) + IEs as `remains`; the event's
+    // IEs start after the AID.
+    let ies = attr_ie(msg).or_else(|| {
+        assoc_frame
+            .as_ref()
+            .map(|frame| frame.remains.get(2..).unwrap_or_default().to_vec())
+    });
 
-    Nl80211Event::Associated {
-        status: status.into(),
-        ies,
-    }
+    Nl80211Event::Associated { status, ies }
 }

--- a/src/event_status.rs
+++ b/src/event_status.rs
@@ -11,7 +11,7 @@ use netlink_packet_core::DecodeError;
 /// by the IEEE standard.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[non_exhaustive]
-pub enum Nl80211EventCode {
+pub enum Ieee80211StatusCode {
     /// IEEE 802.11 status code 0.
     Success,
     /// IEEE 802.11 status code 1.
@@ -379,7 +379,7 @@ const IEEE_OCI_MISMATCH: u16 = 138;
 const IEEE_GAS_QUERY_REQUEST_TOO_LARGE: u16 = 143;
 const IEEE_8021X_AUTH_SUCCESS: u16 = 153;
 
-impl From<u16> for Nl80211EventCode {
+impl From<u16> for Ieee80211StatusCode {
     fn from(v: u16) -> Self {
         match v {
             IEEE_SUCCESS => Self::Success,
@@ -575,7 +575,7 @@ impl From<u16> for Nl80211EventCode {
     }
 }
 
-impl std::fmt::Display for Nl80211EventCode {
+impl std::fmt::Display for Ieee80211StatusCode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Success => f.write_str("success"),
@@ -837,7 +837,7 @@ impl std::fmt::Display for Nl80211EventCode {
     }
 }
 
-impl std::str::FromStr for Nl80211EventCode {
+impl std::str::FromStr for Ieee80211StatusCode {
     type Err = DecodeError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -1048,7 +1048,7 @@ impl std::str::FromStr for Nl80211EventCode {
 /// by the IEEE standard.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[non_exhaustive]
-pub enum Nl80211EventReason {
+pub enum Ieee80211ReasonCode {
     /// IEEE 802.11 reason code 1.
     Unspecified,
     /// IEEE 802.11 reason code 2.
@@ -1251,7 +1251,7 @@ const IEEE_ALTERNATIVE_CHANNEL_OCCUPIED: u16 = 68;
 const IEEE_TIME_SYNC_LOST: u16 = 69;
 const IEEE_POOR_RSSI_CONDITIONS: u16 = 71;
 
-impl From<u16> for Nl80211EventReason {
+impl From<u16> for Ieee80211ReasonCode {
     fn from(v: u16) -> Self {
         match v {
             IEEE_UNSPECIFIED_REASON => Self::Unspecified,
@@ -1338,7 +1338,7 @@ impl From<u16> for Nl80211EventReason {
     }
 }
 
-impl std::fmt::Display for Nl80211EventReason {
+impl std::fmt::Display for Ieee80211ReasonCode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Unspecified => f.write_str("unspecified"),
@@ -1453,7 +1453,7 @@ impl std::fmt::Display for Nl80211EventReason {
     }
 }
 
-impl std::str::FromStr for Nl80211EventReason {
+impl std::str::FromStr for Ieee80211ReasonCode {
     type Err = DecodeError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use crate::Nl80211EventCode;
+use crate::Ieee80211StatusCode;
 use netlink_packet_core::DecodeError;
 
 /// IEEE 802.11 authentication algorithm, from the Authentication Algorithm
@@ -8,7 +8,7 @@ use netlink_packet_core::DecodeError;
 /// constants (`WLAN_AUTH_*` in `include/linux/ieee80211.h`).
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[non_exhaustive]
-pub enum Nl80211AuthAlgorithm {
+pub enum Ieee80211AuthAlgorithm {
     /// `WLAN_AUTH_OPEN` (0): Open System authentication.
     OpenSystem,
     /// `WLAN_AUTH_SHARED_KEY` (1): Shared Key authentication.
@@ -33,7 +33,7 @@ pub enum Nl80211AuthAlgorithm {
     Other(u16),
 }
 
-impl From<u16> for Nl80211AuthAlgorithm {
+impl From<u16> for Ieee80211AuthAlgorithm {
     fn from(alg: u16) -> Self {
         match alg {
             WLAN_AUTH_OPEN => Self::OpenSystem,
@@ -64,36 +64,30 @@ const WLAN_AUTH_IEEE8021X: u16 = 8;
 const WLAN_AUTH_EPPKE: u16 = 9;
 const WLAN_AUTH_LEAP: u16 = 128;
 
-/// A parsed IEEE 802.11 Authentication management frame, as delivered in the
-/// `NL80211_ATTR_FRAME` of an `NL80211_CMD_AUTHENTICATE` event.
+/// A parsed IEEE 802.11 Authentication frame body, as delivered in the
+/// `NL80211_ATTR_FRAME` of an `NL80211_CMD_AUTHENTICATE` event
+/// (IEEE Std 802.11-2024 §9.3.3.11, Table 9-70).
 ///
-/// The frame layout is: 24-byte MAC header (frame control, duration, DA/SA/
-/// BSSID, sequence control), then the fixed Authentication fields
-/// (algorithm, transaction sequence number, status code), then the frame
-/// body (challenge text for Open System/Shared Key, or the SAE commit /
-/// confirm body for SAE).
+/// The fixed fields are the Authentication algorithm number, transaction
+/// sequence number and status code; the remaining body holds the
+/// challenge text for Open System/Shared Key, or the SAE commit / confirm
+/// body for SAE. The 24-byte MAC header (DA/SA/BSSID/sequence, see
+/// §9.2.4.3 and §9.2.4.4) is skipped and not modelled here.
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[non_exhaustive]
-pub struct Nl80211AuthFrame {
-    /// Destination address (Addr1).
-    pub da: [u8; 6],
-    /// Source address (Addr2).
-    pub sa: [u8; 6],
-    /// BSSID (Addr3).
-    pub bssid: [u8; 6],
-    /// Sequence number, from the low 12 bits of the sequence control field.
-    pub sequence: u16,
+pub struct Ieee80211AuthFrame {
     /// Authentication algorithm.
-    pub algorithm: Nl80211AuthAlgorithm,
+    pub algorithm: Ieee80211AuthAlgorithm,
     /// Authentication transaction sequence number.
     pub transaction: u16,
-    /// IEEE 802.11 status code of this frame.
-    pub status: Nl80211EventCode,
-    /// Frame body: challenge text, or the SAE commit / confirm body.
-    pub body: Vec<u8>,
+    /// IEEE 802.11 status code.
+    pub status_code: Ieee80211StatusCode,
+    /// Remaining frame body after the fixed fields: challenge text, or the
+    /// SAE commit / confirm body.
+    pub(crate) remains: Vec<u8>,
 }
 
-impl Nl80211AuthFrame {
+impl Ieee80211AuthFrame {
     /// Parse an Authentication management frame from its raw bytes.
     ///
     /// Returns an error when the frame is shorter than the fixed 30 bytes
@@ -106,20 +100,85 @@ impl Nl80211AuthFrame {
             )));
         }
 
-        let sequence_ctrl = u16::from_le_bytes([data[22], data[23]]);
-        Ok(Nl80211AuthFrame {
-            da: data[4..10].try_into().expect("6-byte DA"),
-            sa: data[10..16].try_into().expect("6-byte SA"),
-            bssid: data[16..22].try_into().expect("6-byte BSSID"),
-            sequence: sequence_ctrl >> 4,
-            algorithm: Nl80211AuthAlgorithm::from(u16::from_le_bytes([
+        Ok(Ieee80211AuthFrame {
+            algorithm: Ieee80211AuthAlgorithm::from(u16::from_le_bytes([
                 data[24], data[25],
             ])),
             transaction: u16::from_le_bytes([data[26], data[27]]),
-            status: Nl80211EventCode::from(u16::from_le_bytes([
+            status_code: Ieee80211StatusCode::from(u16::from_le_bytes([
                 data[28], data[29],
             ])),
-            body: data[30..].to_vec(),
+            remains: data[30..].to_vec(),
+        })
+    }
+}
+
+bitflags::bitflags! {
+    /// IEEE 802.11 Capability Information field (802.11-2020 §9.4.1.4),
+    /// carried by (Re)Association Response frames and Beacon/Probe Response
+    /// frames.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct Ieee80211CapabilityInfo: u16 {
+        const Ess = 0x0001;
+        const Ibss = 0x0002;
+        const CfPollable = 0x0004;
+        const CfPollRequest = 0x0008;
+        const Privacy = 0x0010;
+        const ShortPreamble = 0x0020;
+        const Pbcc = 0x0040;
+        const ChannelAgility = 0x0080;
+        const SpectrumManagement = 0x0100;
+        const Qos = 0x0200;
+        const ShortSlotTime = 0x0400;
+        const Apsd = 0x0800;
+        const RadioMeasurement = 0x1000;
+        const DsssOfdm = 0x2000;
+        const DelayedBlockAck = 0x4000;
+        const ImmediateBlockAck = 0x8000;
+    }
+}
+
+/// A parsed IEEE 802.11 (Re)Association Response frame body, as delivered
+/// in the `NL80211_ATTR_FRAME` of an `NL80211_CMD_ASSOCIATE` event.
+///
+/// The frame body is (IEEE Std 802.11-2024 §9.3.3.6 Table 9-65 /
+/// §9.3.3.8 Table 9-67): Capability Information(2) || Status Code(2) ||
+/// AID(2) || Supported Rates ... The AID and the information elements are
+/// kept as raw `remains`; Association Response and Reassociation Response
+/// share this body layout.
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
+pub struct Ieee80211AssocRespFrame {
+    /// Capability information.
+    pub capability: Ieee80211CapabilityInfo,
+    /// IEEE 802.11 status code.
+    pub status_code: Ieee80211StatusCode,
+    /// Remaining frame body after the fixed fields: AID(2) followed by the
+    /// information elements.
+    pub(crate) remains: Vec<u8>,
+}
+
+impl Ieee80211AssocRespFrame {
+    /// Parse a (Re)Association Response frame from its raw bytes.
+    ///
+    /// Returns an error when the frame is shorter than the fixed 28 bytes
+    /// (24-byte MAC header + capability + status code).
+    pub fn parse(data: &[u8]) -> Result<Self, DecodeError> {
+        if data.len() < 28 {
+            return Err(DecodeError::from(format!(
+                "(re)association response frame too short: {} bytes",
+                data.len()
+            )));
+        }
+
+        Ok(Ieee80211AssocRespFrame {
+            capability: Ieee80211CapabilityInfo::from_bits_truncate(
+                u16::from_le_bytes([data[24], data[25]]),
+            ),
+            status_code: Ieee80211StatusCode::from(u16::from_le_bytes([
+                data[26], data[27],
+            ])),
+            remains: data[28..].to_vec(),
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,12 +74,15 @@ pub use self::element::{
 };
 pub use self::error::Nl80211Error;
 pub use self::event::Nl80211Event;
-pub use self::event_status::{Nl80211EventCode, Nl80211EventReason};
+pub use self::event_status::{Ieee80211ReasonCode, Ieee80211StatusCode};
 pub use self::ext_cap::{
     Nl80211ExtendedCapability, Nl80211IfTypeExtCapa, Nl80211IfTypeExtCapas,
 };
 pub use self::feature::{Nl80211ExtFeature, Nl80211Features};
-pub use self::frame::{Nl80211AuthAlgorithm, Nl80211AuthFrame};
+pub use self::frame::{
+    Ieee80211AssocRespFrame, Ieee80211AuthAlgorithm, Ieee80211AuthFrame,
+    Ieee80211CapabilityInfo,
+};
 pub use self::frame_type::{Nl80211FrameType, Nl80211IfaceFrameType};
 pub use self::handle::Nl80211Handle;
 pub use self::iface::{

--- a/src/tests/event.rs
+++ b/src/tests/event.rs
@@ -17,24 +17,27 @@ use genetlink::message::RawGenlMessage;
 use netlink_packet_core::NetlinkMessage;
 
 use crate::{
-    Nl80211Command, Nl80211Event, Nl80211EventCode, Nl80211EventReason,
+    Ieee80211ReasonCode, Ieee80211StatusCode, Nl80211Command, Nl80211Event,
     Nl80211WowlanWakeup,
 };
 
-// Nl80211EventCode: known IEEE 802.11 status codes map to named variants,
+// Ieee80211StatusCode: known IEEE 802.11 status codes map to named variants,
 // anything else keeps the raw code in `Other`.
 #[test]
 fn test_event_status_conversion() {
-    assert_eq!(Nl80211EventCode::Success, Nl80211EventCode::from(0));
+    assert_eq!(Ieee80211StatusCode::Success, Ieee80211StatusCode::from(0));
     assert_eq!(
-        Nl80211EventCode::ApUnableToHandleNewSta,
-        Nl80211EventCode::from(17)
+        Ieee80211StatusCode::ApUnableToHandleNewSta,
+        Ieee80211StatusCode::from(17)
     );
     assert_eq!(
-        Nl80211EventCode::SaeHashToElement,
-        Nl80211EventCode::from(126)
+        Ieee80211StatusCode::SaeHashToElement,
+        Ieee80211StatusCode::from(126)
     );
-    assert_eq!(Nl80211EventCode::Other(1234), Nl80211EventCode::from(1234));
+    assert_eq!(
+        Ieee80211StatusCode::Other(1234),
+        Ieee80211StatusCode::from(1234)
+    );
 }
 
 // Display / FromStr: lowercase snake_case names round-trip; unknown strings
@@ -42,26 +45,29 @@ fn test_event_status_conversion() {
 #[test]
 fn test_event_status_display_fromstr() {
     for (status, name) in [
-        (Nl80211EventCode::Success, "success"),
+        (Ieee80211StatusCode::Success, "success"),
         (
-            Nl80211EventCode::ApUnableToHandleNewSta,
+            Ieee80211StatusCode::ApUnableToHandleNewSta,
             "ap_unable_to_handle_new_sta",
         ),
-        (Nl80211EventCode::RejectUPidSetting, "reject_u_pid_setting"),
-        (Nl80211EventCode::Other(1234), "1234"),
+        (
+            Ieee80211StatusCode::RejectUPidSetting,
+            "reject_u_pid_setting",
+        ),
+        (Ieee80211StatusCode::Other(1234), "1234"),
     ] {
         assert_eq!(name, status.to_string());
         assert_eq!(status, name.parse().unwrap());
     }
     // Numeric strings map through `From<u16>`.
     assert_eq!(
-        Nl80211EventCode::ApUnableToHandleNewSta,
+        Ieee80211StatusCode::ApUnableToHandleNewSta,
         "17".parse().unwrap()
     );
-    assert!("bogus".parse::<Nl80211EventCode>().is_err());
+    assert!("bogus".parse::<Ieee80211StatusCode>().is_err());
 }
 
-// Nl80211AuthFrame::parse: SAE Authentication frame (transaction 1) from
+// Ieee80211AuthFrame::parse: SAE Authentication frame (transaction 1) from
 // the same capture as test_captured_authenticate_event.
 #[test]
 fn test_parse_auth_frame_sae() {
@@ -79,20 +85,16 @@ fn test_parse_auth_frame_sae() {
         0x2f, 0xc2, 0xcb, 0x59, 0x1f, 0xa7, 0xdd, 0xe0,
     ];
     let frame =
-        crate::Nl80211AuthFrame::parse(&raw).expect("parse SAE auth frame");
-    assert_eq!([0x02, 0x00, 0x00, 0x00, 0x00, 0x00], frame.da);
-    assert_eq!([0x02, 0x00, 0x00, 0x00, 0x01, 0x00], frame.sa);
-    assert_eq!([0x02, 0x00, 0x00, 0x00, 0x01, 0x00], frame.bssid);
-    assert_eq!(14, frame.sequence);
-    assert_eq!(crate::Nl80211AuthAlgorithm::Sae, frame.algorithm);
+        crate::Ieee80211AuthFrame::parse(&raw).expect("parse SAE auth frame");
+    assert_eq!(crate::Ieee80211AuthAlgorithm::Sae, frame.algorithm);
     assert_eq!(1, frame.transaction);
-    assert_eq!(Nl80211EventCode::Success, frame.status);
+    assert_eq!(Ieee80211StatusCode::Success, frame.status_code);
     // SAE commit body: group(2)=19, then scalar + element.
-    assert_eq!(98, frame.body.len());
-    assert_eq!(&[0x13, 0x00], &frame.body[0..2]);
+    assert_eq!(98, frame.remains.len());
+    assert_eq!(&[0x13, 0x00], &frame.remains[0..2]);
 }
 
-// Nl80211AuthFrame::parse: Open System Authentication frame (transaction 2,
+// Ieee80211AuthFrame::parse: Open System Authentication frame (transaction 2,
 // empty body) captured from the WPA2-PSK connection.
 #[test]
 fn test_parse_auth_frame_open() {
@@ -102,50 +104,50 @@ fn test_parse_auth_frame_open() {
         0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
     ];
     let frame =
-        crate::Nl80211AuthFrame::parse(&raw).expect("parse open auth frame");
-    assert_eq!(crate::Nl80211AuthAlgorithm::OpenSystem, frame.algorithm);
+        crate::Ieee80211AuthFrame::parse(&raw).expect("parse open auth frame");
+    assert_eq!(crate::Ieee80211AuthAlgorithm::OpenSystem, frame.algorithm);
     assert_eq!(2, frame.transaction);
-    assert_eq!(Nl80211EventCode::Success, frame.status);
-    assert!(frame.body.is_empty());
+    assert_eq!(Ieee80211StatusCode::Success, frame.status_code);
+    assert!(frame.remains.is_empty());
 }
 
-// Nl80211EventReason: conversion, Display / FromStr round-trip.
+// Ieee80211ReasonCode: conversion, Display / FromStr round-trip.
 #[test]
 fn test_event_reason_conversion() {
     assert_eq!(
-        Nl80211EventReason::DeauthLeaving,
-        Nl80211EventReason::from(3)
+        Ieee80211ReasonCode::DeauthLeaving,
+        Ieee80211ReasonCode::from(3)
     );
     assert_eq!(
-        Nl80211EventReason::FourWayHandshakeTimeout,
-        Nl80211EventReason::from(15)
+        Ieee80211ReasonCode::FourWayHandshakeTimeout,
+        Ieee80211ReasonCode::from(15)
     );
-    assert_eq!(Nl80211EventReason::MeshChan, Nl80211EventReason::from(66));
+    assert_eq!(Ieee80211ReasonCode::MeshChan, Ieee80211ReasonCode::from(66));
     assert_eq!(
-        Nl80211EventReason::Other(999),
-        Nl80211EventReason::from(999)
+        Ieee80211ReasonCode::Other(999),
+        Ieee80211ReasonCode::from(999)
     );
 
     for (reason, name) in [
-        (Nl80211EventReason::DeauthLeaving, "deauth_leaving"),
+        (Ieee80211ReasonCode::DeauthLeaving, "deauth_leaving"),
         (
-            Nl80211EventReason::FourWayHandshakeTimeout,
+            Ieee80211ReasonCode::FourWayHandshakeTimeout,
             "four_way_handshake_timeout",
         ),
-        (Nl80211EventReason::Ieee8021xFailed, "ieee8021x_failed"),
-        (Nl80211EventReason::Other(42), "42"),
+        (Ieee80211ReasonCode::Ieee8021xFailed, "ieee8021x_failed"),
+        (Ieee80211ReasonCode::Other(42), "42"),
     ] {
         assert_eq!(name, reason.to_string());
         assert_eq!(reason, name.parse().unwrap());
     }
-    assert_eq!(Nl80211EventReason::DeauthLeaving, "3".parse().unwrap());
-    assert!("bogus".parse::<Nl80211EventReason>().is_err());
+    assert_eq!(Ieee80211ReasonCode::DeauthLeaving, "3".parse().unwrap());
+    assert!("bogus".parse::<Ieee80211ReasonCode>().is_err());
 }
 
 // Too-short frames are rejected.
 #[test]
 fn test_parse_auth_frame_too_short() {
-    assert!(crate::Nl80211AuthFrame::parse(&[0u8; 10]).is_err());
+    assert!(crate::Ieee80211AuthFrame::parse(&[0u8; 10]).is_err());
 }
 
 fn parse_event(raw: &[u8]) -> Option<Nl80211Event> {
@@ -176,7 +178,7 @@ fn test_captured_authenticate_event() {
     ];
     match parse_event(&raw).expect("parse event") {
         Nl80211Event::Authenticated { status, frame } => {
-            assert_eq!(Nl80211EventCode::Success, status);
+            assert_eq!(Ieee80211StatusCode::Success, status);
             let frame = frame.expect("auth frame");
             assert_eq!(128, frame.len());
             // 802.11 auth frame: management subtype auth, SAE alg (3),
@@ -190,9 +192,12 @@ fn test_captured_authenticate_event() {
 
 // NL80211_CMD_ASSOCIATE event: the association response. The IEs are not in
 // an NL80211_ATTR_IE but inside the frame, after offset 30.
-#[test]
-fn test_captured_associate_event() {
-    let raw = vec![
+//
+// The captured event has no NL80211_ATTR_STATUS_CODE; the IEEE status code
+// lives at frame offset 26 (24-byte 802.11 header + capability(2)). Build the
+// same event with an arbitrary status code for the success/rejection tests.
+fn captured_associate_event_raw(status: u16) -> Vec<u8> {
+    let mut raw = vec![
         0xcc, 0x00, 0x00, 0x00, 0x32, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x26, 0x01, 0x00, 0x00, 0x08, 0x00, 0x01, 0x00,
         0x12, 0x00, 0x00, 0x00, 0x08, 0x00, 0x03, 0x00, 0xd3, 0x01, 0x00, 0x00,
@@ -211,11 +216,67 @@ fn test_captured_associate_event() {
         0x79, 0x7a, 0x7b, 0x7c, 0x7d, 0x7e, 0x7f, 0x80, 0x81, 0x00, 0x82, 0x80,
         0x0c, 0x00, 0x81, 0x00, 0x05, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
     ];
+    // Frame starts at byte 40 (after the netlink/genl headers and the
+    // NL80211_ATTR_FRAME attribute header); the IEEE status code is at frame
+    // offset 26.
+    raw[40 + 26] = status as u8;
+    raw[40 + 27] = (status >> 8) as u8;
+    raw
+}
+
+/// The 802.11 (Re)Association Response frame from
+/// [`captured_associate_event_raw`], with the netlink/genl and
+/// `NL80211_ATTR_FRAME` attribute headers stripped (frame payload is 56
+/// bytes: 28 fixed + AID(2) + 26 IEs).
+fn captured_assoc_resp_frame(status: u16) -> Vec<u8> {
+    let raw = captured_associate_event_raw(status);
+    raw[40..40 + 56].to_vec()
+}
+
+#[test]
+fn test_captured_associate_event() {
+    let raw = captured_associate_event_raw(0);
     match parse_event(&raw).expect("parse event") {
         Nl80211Event::Associated { status, ies } => {
-            assert_eq!(Nl80211EventCode::Success, status);
+            assert_eq!(Ieee80211StatusCode::Success, status);
             // Supported rates IE starts the response IEs.
             let ies = ies.expect("assoc IEs");
+            assert_eq!(26, ies.len());
+            assert_eq!(&ies[0..3], &[0x01, 0x08, 0x82]);
+        }
+        other => panic!("unexpected event: {other:?}"),
+    }
+}
+
+// Ieee80211AssocRespFrame::parse: the fixed (Re)Association Response fields
+// are read from the standard frame layout instead of relying on
+// NL80211_ATTR_STATUS_CODE.
+#[test]
+fn test_parse_assoc_resp_frame() {
+    let frame =
+        crate::Ieee80211AssocRespFrame::parse(&captured_assoc_resp_frame(1))
+            .expect("parse assoc resp frame");
+    assert_eq!(
+        crate::Ieee80211CapabilityInfo::Ess
+            | crate::Ieee80211CapabilityInfo::Privacy
+            | crate::Ieee80211CapabilityInfo::ShortSlotTime,
+        frame.capability
+    );
+    assert_eq!(Ieee80211StatusCode::UnspecifiedFailure, frame.status_code);
+    // remains = AID(2) followed by the response IEs.
+    assert_eq!(28, frame.remains.len());
+    assert_eq!(&frame.remains[2..5], &[0x01, 0x08, 0x82]);
+}
+
+// NL80211_CMD_ASSOCIATE event carrying a rejected (Re)Association Response:
+// status code 1 must be surfaced instead of defaulting to Success.
+#[test]
+fn test_captured_rejected_associate_event() {
+    let raw = captured_associate_event_raw(1);
+    match parse_event(&raw).expect("parse event") {
+        Nl80211Event::Associated { status, ies } => {
+            assert_eq!(Ieee80211StatusCode::UnspecifiedFailure, status);
+            let ies = ies.expect("rejected assoc response IEs");
             assert_eq!(26, ies.len());
             assert_eq!(&ies[0..3], &[0x01, 0x08, 0x82]);
         }
@@ -246,7 +307,7 @@ fn test_captured_connect_result_event() {
     ];
     assert_eq!(
         Nl80211Event::ConnectResult {
-            status: Nl80211EventCode::Success,
+            status: Ieee80211StatusCode::Success,
         },
         parse_event(&raw).expect("parse event")
     );
@@ -263,7 +324,7 @@ fn test_captured_disconnect_event() {
     ];
     assert_eq!(
         Nl80211Event::Disconnect {
-            reason: Nl80211EventReason::DeauthLeaving,
+            reason: Ieee80211ReasonCode::DeauthLeaving,
         },
         parse_event(&raw).expect("parse event")
     );
@@ -286,7 +347,7 @@ fn test_captured_deauthenticated_event() {
     ];
     assert_eq!(
         Nl80211Event::Deauthenticated {
-            reason: Nl80211EventReason::PrevAuthNotValid,
+            reason: Ieee80211ReasonCode::PrevAuthNotValid,
         },
         parse_event(&raw).expect("parse event")
     );
@@ -307,7 +368,7 @@ fn test_captured_disassociated_event() {
     ];
     assert_eq!(
         Nl80211Event::Disassociated {
-            reason: Nl80211EventReason::PrevAuthNotValid,
+            reason: Ieee80211ReasonCode::PrevAuthNotValid,
         },
         parse_event(&raw).expect("parse event")
     );


### PR DESCRIPTION
Problem:

Given a rejected (Re)Association Response delivered as an
NL80211_CMD_ASSOCIATE event without NL80211_ATTR_STATUS_CODE, the status
was defaulted to Success and the rejection was misreported by callers.

Root cause:

The kernel sends these events with the full IEEE 802.11 frame in
NL80211_ATTR_FRAME only. The status code is a field of the standard
frame body, not a netlink attribute, and parse_associate() did not read
it from the frame.

Fix:

Add Ieee80211AssocRespFrame and Ieee80211CapabilityInfo and parse the
frame body per IEEE Std 802.11-2024 9.3.3.6/9.3.3.8 (capability, status
code, then AID + IEs as raw remains). IEEE-standard types are renamed to
the Ieee80211 prefix (Ieee80211StatusCode, Ieee80211ReasonCode,
Ieee80211AuthFrame, Ieee80211AuthAlgorithm) and the frame parsers model
the standard frame body instead of MAC header fields.

Unit test cases included.