### PR TITLE
cqm: SET_CQM request + NOTIFY_CQM RSSI event

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -35,6 +35,7 @@ use netlink_packet_core::{
     NlasIterator, Parseable, ParseableParametrized, NLA_F_NESTED,
 };
 
+use crate::mac::ETH_ALEN;
 use crate::{
     bytes::{write_u16, write_u32, write_u64},
     scan::{NestedIndexedNlaList, Nla80211ScanFreqNlas, Nla80211ScanSsidNlas},
@@ -42,7 +43,7 @@ use crate::{
     Ieee80211AkmSuite, Ieee80211CipherSuite, Ieee80211ExtendedCapability,
     Ieee80211HtCapabilityMask, Ieee80211VhtCapability, Nl80211AuthType,
     Nl80211Band, Nl80211BandTypes, Nl80211BssInfo, Nl80211ChannelWidth,
-    Nl80211Command, Nl80211ExtFeature, Nl80211ExtFeatures,
+    Nl80211Command, Nl80211CqmAttr, Nl80211ExtFeature, Nl80211ExtFeatures,
     Nl80211ExternalAuthAction, Nl80211Features, Nl80211HtWiphyChannelType,
     Nl80211IfMode, Nl80211IfTypeExtCapa, Nl80211IfTypeExtCapas,
     Nl80211IfaceComb, Nl80211IfaceFrameType, Nl80211InterfaceType,
@@ -51,8 +52,6 @@ use crate::{
     Nl80211StationInfo, Nl80211SurveyInfo, Nl80211TransmitQueueStat,
     Nl80211UseMfp, Nl80211WowlanTriggersSupport, Nl80211WpaVersions,
 };
-
-const ETH_ALEN: usize = 6;
 
 fn parse_cipher_suites(
     payload: &[u8],
@@ -277,7 +276,7 @@ const NL80211_ATTR_WIPHY_COVERAGE_CLASS: u16 = 89;
 const NL80211_ATTR_FRAME_MATCH: u16 = 91;
 const NL80211_ATTR_ACK: u16 = 92;
 // const NL80211_ATTR_PS_STATE:u16 = 93;
-// const NL80211_ATTR_CQM:u16 = 94;
+const NL80211_ATTR_CQM: u16 = 94;
 // const NL80211_ATTR_LOCAL_STATE_CHANGE:u16 = 95;
 // const NL80211_ATTR_AP_ISOLATE:u16 = 96;
 // const NL80211_ATTR_WIPHY_TX_POWER_SETTING:u16 = 97;
@@ -752,6 +751,11 @@ pub enum Nl80211Attr {
     /// (u8): the driver should trigger reauthentication when this percentage
     /// of the PMK lifetime has elapsed. Used with `NL80211_CMD_SET_PMKSA`.
     PmkReauthThreshold(u8),
+    /// Connection quality monitor configuration, carried as the nested
+    /// `NL80211_ATTR_CQM` attribute (a list of [`Nl80211CqmAttr`]
+    /// sub-attributes). Used with `NL80211_CMD_SET_CQM` and present in
+    /// `NL80211_CMD_NOTIFY_CQM` events.
+    Cqm(Vec<Nl80211CqmAttr>),
     Other(DefaultNla),
     /// 24-bit OUI, or an as yet unused Linux-specific ID.
     ///
@@ -900,6 +904,7 @@ impl Nla for Nl80211Attr {
             Self::Key(nlas) => nlas.as_slice().buffer_len(),
             Self::RekeyData(nlas) => nlas.as_slice().buffer_len(),
             Self::WowlanTriggers(nlas) => nlas.as_slice().buffer_len(),
+            Self::Cqm(nlas) => nlas.as_slice().buffer_len(),
             Self::Other(attr) => attr.value_len(),
             Self::VendorData(d) => d.len(),
         }
@@ -1035,6 +1040,7 @@ impl Nla for Nl80211Attr {
             Self::Key(_) => NL80211_ATTR_KEY,
             Self::RekeyData(_) => NL80211_ATTR_REKEY_DATA,
             Self::WowlanTriggers(_) => NL80211_ATTR_WOWLAN_TRIGGERS,
+            Self::Cqm(_) => NL80211_ATTR_CQM | NLA_F_NESTED,
             Self::FrameType(_) => NL80211_ATTR_FRAME_TYPE,
             Self::Cookie(_) => NL80211_ATTR_COOKIE,
             Self::Ack => NL80211_ATTR_ACK,
@@ -1236,6 +1242,7 @@ impl Nla for Nl80211Attr {
             Self::Key(nlas) => nlas.as_slice().emit(buffer),
             Self::RekeyData(nlas) => nlas.as_slice().emit(buffer),
             Self::WowlanTriggers(nlas) => nlas.as_slice().emit(buffer),
+            Self::Cqm(nlas) => nlas.as_slice().emit(buffer),
             Self::Other(attr) => attr.emit_value(buffer),
         }
     }
@@ -1984,6 +1991,11 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nl80211Attr {
             }
             NL80211_ATTR_SOCKET_OWNER => Self::SocketOwner,
             NL80211_ATTR_CONTROL_PORT_NO_ENCRYPT => Self::ControlPortNoEncrypt,
+            NL80211_ATTR_CQM => {
+                let cqm = Nl80211CqmAttr::parse_list(payload)
+                    .context("Invalid NL80211_ATTR_CQM")?;
+                Self::Cqm(cqm)
+            }
             _ => Self::Other(
                 DefaultNla::parse(buf).context("invalid NLA (unknown kind)")?,
             ),

--- a/src/connect/handle.rs
+++ b/src/connect/handle.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     Nl80211AssociateRequest, Nl80211Attr, Nl80211AuthenticateRequest,
-    Nl80211ConnectRequest, Nl80211ControlPortFrameRequest,
+    Nl80211ConnectRequest, Nl80211ControlPortFrameRequest, Nl80211CqmRequest,
     Nl80211DelPmkRequest, Nl80211DelPmksaRequest, Nl80211DisconnectRequest,
     Nl80211ExternalAuthRequest, Nl80211FlushPmksaRequest, Nl80211FrameRequest,
     Nl80211Handle, Nl80211KeyRequest, Nl80211RegisterFrameRequest,
@@ -212,5 +212,21 @@ impl Nl80211ConnectionHandle {
         attributes: Vec<Nl80211Attr>,
     ) -> Nl80211DelPmkRequest {
         Nl80211DelPmkRequest::new(self.0.clone(), attributes)
+    }
+
+    /// Configure the kernel's connection quality monitor
+    /// (`NL80211_CMD_SET_CQM`): the kernel reports a
+    /// `NL80211_CMD_NOTIFY_CQM` event when the connected AP's RSSI
+    /// crosses the configured threshold.
+    ///
+    /// The `attributes` are normally produced by [`crate::Nl80211Cqm`],
+    /// e.g. `Nl80211Cqm::new(if_index).rssi_thold(-70).rssi_hyst(5)
+    /// .build()`. Fails with `-EOPNOTSUPP` on drivers without CQM
+    /// support.
+    pub fn set_cqm(
+        &mut self,
+        attributes: Vec<Nl80211Attr>,
+    ) -> Nl80211CqmRequest {
+        Nl80211CqmRequest::new(self.0.clone(), attributes)
     }
 }

--- a/src/cqm.rs
+++ b/src/cqm.rs
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: MIT
+
+// Most documentation comments are copied and modified from linux kernel
+// include/uapi/linux/nl80211.h which is holding these license disclaimer:
+/*
+ * 802.11 netlink interface public header
+ *
+ * Copyright 2006-2010 Johannes Berg <johannes@sipsolutions.net>
+ * Copyright 2008 Michael Wu <flamingice@sourmilk.net>
+ * Copyright 2008 Luis Carlos Cobo <luisca@cozybit.com>
+ * Copyright 2008 Michael Buesch <m@bues.ch>
+ * Copyright 2008, 2009 Luis R. Rodriguez <lrodriguez@atheros.com>
+ * Copyright 2008 Jouni Malinen <jouni.malinen@atheros.com>
+ * Copyright 2008 Colin McCabe <colin@cozybit.com>
+ * Copyright 2015-2017 Intel Deutschland GmbH
+ * Copyright (C) 2018-2024 Intel Corporation
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+use futures::TryStream;
+use netlink_packet_core::{
+    parse_i32, parse_u32, DecodeError, DefaultNla, ErrorContext, Nla,
+    NlaBuffer, NlasIterator, Parseable, NLM_F_ACK, NLM_F_REQUEST,
+};
+use netlink_packet_generic::GenlMessage;
+
+use crate::mac::ETH_ALEN;
+use crate::{
+    bytes::write_i32, bytes::write_u32, nl80211_execute, Nl80211Attr,
+    Nl80211Command, Nl80211Error, Nl80211Handle, Nl80211Message,
+};
+
+// NL80211_ATTR_CQM nested sub-attribute ids (enum nl80211_attr_cqm).
+const NL80211_ATTR_CQM_RSSI_THOLD: u16 = 1;
+const NL80211_ATTR_CQM_RSSI_HYST: u16 = 2;
+const NL80211_ATTR_CQM_RSSI_THRESHOLD_EVENT: u16 = 3;
+// const NL80211_ATTR_CQM_PKT_LOSS_EVENT: u16 = 4;
+// const NL80211_ATTR_CQM_TXE_RATE: u16 = 5;
+// const NL80211_ATTR_CQM_TXE_PKTS: u16 = 6;
+// const NL80211_ATTR_CQM_TXE_INTVL: u16 = 7;
+// const NL80211_ATTR_CQM_BEACON_LOSS_EVENT: u16 = 8;
+const NL80211_ATTR_CQM_RSSI_LEVEL: u16 = 9;
+
+/// RSSI threshold crossing direction of a `NL80211_CMD_NOTIFY_CQM` event
+/// (enum nl80211_cqm_rssi_threshold_event).
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum Nl80211CqmRssiThresholdEvent {
+    /// The RSSI level is lower than the configured threshold.
+    Low,
+    /// The RSSI is higher than the configured threshold.
+    High,
+    /// Unknown / future kernel event value.
+    Other(u32),
+}
+
+impl From<u32> for Nl80211CqmRssiThresholdEvent {
+    fn from(v: u32) -> Self {
+        match v {
+            0 => Self::Low,
+            1 => Self::High,
+            other => Self::Other(other),
+        }
+    }
+}
+
+impl From<Nl80211CqmRssiThresholdEvent> for u32 {
+    fn from(v: Nl80211CqmRssiThresholdEvent) -> Self {
+        match v {
+            Nl80211CqmRssiThresholdEvent::Low => 0,
+            Nl80211CqmRssiThresholdEvent::High => 1,
+            Nl80211CqmRssiThresholdEvent::Other(v) => v,
+        }
+    }
+}
+
+/// A `NL80211_CMD_NOTIFY_CQM` event reported by the kernel: the
+/// `NL80211_ATTR_WIPHY` / `NL80211_ATTR_IFINDEX` of the reporting
+/// interface, the peer MAC (`NL80211_ATTR_MAC`, when the kernel included
+/// it) and the full list of `NL80211_ATTR_CQM` sub-attributes.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Nl80211CqmRssiEvent {
+    /// `NL80211_ATTR_WIPHY`: the wiphy index of the reporting interface.
+    pub wiphy: u32,
+    /// `NL80211_ATTR_IFINDEX`: the interface index.
+    pub if_index: u32,
+    /// `NL80211_ATTR_MAC`: the peer MAC, when the kernel included it.
+    pub mac: Option<[u8; ETH_ALEN]>,
+    /// The nested `NL80211_ATTR_CQM` sub-attributes (`RssiThresholdEvent`,
+    /// `RssiLevel`, ...).
+    pub events: Vec<Nl80211CqmAttr>,
+}
+
+/// Sub-attribute of the nested `NL80211_ATTR_CQM` attribute
+/// (`NL80211_CMD_SET_CQM` / `NL80211_CMD_NOTIFY_CQM`).
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum Nl80211CqmAttr {
+    /// `NL80211_ATTR_CQM_RSSI_THOLD`: RSSI threshold in dBm. The kernel
+    /// reports a `NL80211_CMD_NOTIFY_CQM` event when the measured RSSI
+    /// crosses it. Negative value `0` disables RSSI monitoring.
+    RssiThold(i32),
+    /// `NL80211_ATTR_CQM_RSSI_HYST`: RSSI hysteresis in dBm, the kernel
+    /// re-arms the opposite event only after the signal moved past the
+    /// threshold by this amount.
+    RssiHyst(u32),
+    /// `NL80211_ATTR_CQM_RSSI_THRESHOLD_EVENT`: which threshold was
+    /// crossed in a `NL80211_CMD_NOTIFY_CQM` event.
+    RssiThresholdEvent(Nl80211CqmRssiThresholdEvent),
+    /// `NL80211_ATTR_CQM_RSSI_LEVEL`: the RSSI value in dBm that
+    /// triggered a `NL80211_CMD_NOTIFY_CQM` event.
+    RssiLevel(i32),
+    /// Unknown / unmodelled sub-attribute.
+    Other(DefaultNla),
+}
+
+impl Nla for Nl80211CqmAttr {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::RssiThold(_)
+            | Self::RssiHyst(_)
+            | Self::RssiThresholdEvent(_)
+            | Self::RssiLevel(_) => 4,
+            Self::Other(v) => v.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::RssiThold(_) => NL80211_ATTR_CQM_RSSI_THOLD,
+            Self::RssiHyst(_) => NL80211_ATTR_CQM_RSSI_HYST,
+            Self::RssiThresholdEvent(_) => {
+                NL80211_ATTR_CQM_RSSI_THRESHOLD_EVENT
+            }
+            Self::RssiLevel(_) => NL80211_ATTR_CQM_RSSI_LEVEL,
+            Self::Other(v) => v.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::RssiThold(d) => write_i32(buffer, *d),
+            Self::RssiHyst(d) => write_u32(buffer, *d),
+            Self::RssiThresholdEvent(d) => write_u32(buffer, u32::from(*d)),
+            Self::RssiLevel(d) => write_i32(buffer, *d),
+            Self::Other(v) => v.emit_value(buffer),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
+    for Nl80211CqmAttr
+{
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            NL80211_ATTR_CQM_RSSI_THOLD => {
+                let err_msg = format!(
+                    "Invalid NL80211_ATTR_CQM_RSSI_THOLD value {payload:?}"
+                );
+                Self::RssiThold(parse_i32(payload).context(err_msg)?)
+            }
+            NL80211_ATTR_CQM_RSSI_HYST => {
+                let err_msg = format!(
+                    "Invalid NL80211_ATTR_CQM_RSSI_HYST value {payload:?}"
+                );
+                Self::RssiHyst(parse_u32(payload).context(err_msg)?)
+            }
+            NL80211_ATTR_CQM_RSSI_THRESHOLD_EVENT => {
+                let err_msg = format!(
+                    "Invalid NL80211_ATTR_CQM_RSSI_THRESHOLD_EVENT value \
+                    {payload:?}"
+                );
+                Self::RssiThresholdEvent(
+                    parse_u32(payload).context(err_msg)?.into(),
+                )
+            }
+            NL80211_ATTR_CQM_RSSI_LEVEL => {
+                let err_msg = format!(
+                    "Invalid NL80211_ATTR_CQM_RSSI_LEVEL value {payload:?}"
+                );
+                Self::RssiLevel(parse_i32(payload).context(err_msg)?)
+            }
+            _ => Self::Other(
+                DefaultNla::parse(buf).context("invalid NLA (unknown kind)")?,
+            ),
+        })
+    }
+}
+
+impl Nl80211CqmAttr {
+    pub(crate) fn parse_list(
+        payload: &[u8],
+    ) -> Result<Vec<Nl80211CqmAttr>, DecodeError> {
+        let mut attrs = Vec::new();
+        for nla in NlasIterator::new(payload) {
+            let nla = &nla.context("invalid NL80211_ATTR_CQM")?;
+            attrs.push(Nl80211CqmAttr::parse(nla)?);
+        }
+        Ok(attrs)
+    }
+}
+
+/// Helper to build the attribute list for a `NL80211_CMD_SET_CQM` request,
+/// arming the kernel's connection quality monitor (RSSI threshold crossing
+/// notifications, `NL80211_CMD_NOTIFY_CQM` events).
+///
+/// The kernel measures the connected AP's RSSI (typically from beacons)
+/// and emits a `NL80211_CQM_RSSI_THRESHOLD_EVENT` when it crosses the
+/// threshold. Drivers without CQM support (e.g. some beacon-filtering
+/// mac80211 radios) reply `-EOPNOTSUPP`.
+#[derive(Debug)]
+pub struct Nl80211Cqm;
+
+impl Nl80211Cqm {
+    /// Start building a `NL80211_CMD_SET_CQM` request for `if_index`.
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(if_index: u32) -> Nl80211CqmRequestBuilder {
+        Nl80211CqmRequestBuilder {
+            if_index,
+            rssi_thold: None,
+            rssi_hyst: None,
+        }
+    }
+}
+
+/// Builder for the attributes of a `NL80211_CMD_SET_CQM` request.
+#[derive(Debug)]
+pub struct Nl80211CqmRequestBuilder {
+    if_index: u32,
+    rssi_thold: Option<i32>,
+    rssi_hyst: Option<u32>,
+}
+
+impl Nl80211CqmRequestBuilder {
+    /// The RSSI threshold in dBm below which the kernel reports a LOW
+    /// `NL80211_CMD_NOTIFY_CQM` event.
+    pub fn rssi_thold(mut self, thold: i32) -> Self {
+        self.rssi_thold = Some(thold);
+        self
+    }
+
+    /// The RSSI hysteresis in dBm; the kernel only reports the HIGH
+    /// (recovered) event after the signal moved this far above the
+    /// threshold.
+    pub fn rssi_hyst(mut self, hyst: u32) -> Self {
+        self.rssi_hyst = Some(hyst);
+        self
+    }
+
+    /// Build the attribute list for a `NL80211_CMD_SET_CQM` request.
+    pub fn build(self) -> Vec<Nl80211Attr> {
+        let mut cqm = Vec::new();
+        if let Some(thold) = self.rssi_thold {
+            cqm.push(Nl80211CqmAttr::RssiThold(thold));
+        }
+        if let Some(hyst) = self.rssi_hyst {
+            cqm.push(Nl80211CqmAttr::RssiHyst(hyst));
+        }
+        vec![Nl80211Attr::IfIndex(self.if_index), Nl80211Attr::Cqm(cqm)]
+    }
+}
+
+/// Sends a `NL80211_CMD_SET_CQM` request.
+pub struct Nl80211CqmRequest {
+    handle: Nl80211Handle,
+    attributes: Vec<Nl80211Attr>,
+}
+
+impl Nl80211CqmRequest {
+    pub(crate) fn new(
+        handle: Nl80211Handle,
+        attributes: Vec<Nl80211Attr>,
+    ) -> Self {
+        Nl80211CqmRequest { handle, attributes }
+    }
+
+    /// Send the `NL80211_CMD_SET_CQM` request.
+    ///
+    /// A successful return only means the request was accepted by the
+    /// kernel; unsupported drivers reply with a netlink error
+    /// (`-EOPNOTSUPP`).
+    pub async fn execute(
+        self,
+    ) -> impl TryStream<Ok = GenlMessage<Nl80211Message>, Error = Nl80211Error>
+    {
+        let Nl80211CqmRequest {
+            mut handle,
+            attributes,
+        } = self;
+        let nl80211_msg = Nl80211Message {
+            cmd: Nl80211Command::SetCqm,
+            attributes,
+        };
+        nl80211_execute(&mut handle, nl80211_msg, NLM_F_REQUEST | NLM_F_ACK)
+            .await
+    }
+}

--- a/src/event.rs
+++ b/src/event.rs
@@ -6,7 +6,8 @@ use netlink_packet_core::{NetlinkMessage, NetlinkPayload};
 use crate::event_status::{Ieee80211ReasonCode, Ieee80211StatusCode};
 use crate::{
     Ieee80211AssocRespFrame, Ieee80211AuthFrame, Nl80211Attr, Nl80211Command,
-    Nl80211Message, Nl80211WowlanTriggersSupport, Nl80211WowlanWakeup,
+    Nl80211CqmRssiEvent, Nl80211Message, Nl80211WowlanTriggersSupport,
+    Nl80211WowlanWakeup,
 };
 
 /// A multicast nl80211 event received from the kernel, e.g. on the `mlme`,
@@ -61,6 +62,12 @@ pub enum Nl80211Event {
     /// was suspended; `reasons` carries the `NL80211_ATTR_WOWLAN_TRIGGERS`
     /// sub-attributes reported by `cfg80211_report_wowlan_wakeup()`.
     WowlanWakeup { reasons: Vec<Nl80211WowlanWakeup> },
+    /// `NL80211_CMD_NOTIFY_CQM` event: the connection quality monitor
+    /// reported an RSSI threshold crossing of the connected AP. `wiphy` /
+    /// `if_index` identify the reporting interface, `mac` the peer (when
+    /// the kernel included it) and `events` the `NL80211_ATTR_CQM`
+    /// sub-attributes (threshold crossing direction, RSSI level, ...).
+    CqmRssi(Nl80211CqmRssiEvent),
     /// Any other command: carries the unmodelled [`Nl80211Command`].
     Unknown { cmd: Nl80211Command },
 }
@@ -133,6 +140,9 @@ impl Nl80211Event {
                                 attr_frame(&nl_msg).map(|frame| {
                                     Nl80211Event::ControlPortFrame { frame }
                                 })
+                            }
+                            Nl80211Command::NotifyCqm => {
+                                Some(parse_cqm(&nl_msg))
                             }
                             // The kernel also uses SET_WOWLAN as a wakeup
                             // notification; without the wakeup attribute
@@ -263,6 +273,28 @@ fn attr_ie(msg: &Nl80211Message) -> Option<Vec<u8>> {
     msg.attributes.iter().find_map(|attr| match attr {
         Nl80211Attr::Ie(ie) => Some(ie.clone()),
         _ => None,
+    })
+}
+
+fn parse_cqm(msg: &Nl80211Message) -> Nl80211Event {
+    let mut wiphy = 0;
+    let mut if_index = 0;
+    let mut mac = None;
+    let mut events = Vec::new();
+    for attr in &msg.attributes {
+        match attr {
+            Nl80211Attr::Wiphy(w) => wiphy = *w,
+            Nl80211Attr::IfIndex(i) => if_index = *i,
+            Nl80211Attr::Mac(m) => mac = Some(*m),
+            Nl80211Attr::Cqm(cqm) => events.extend(cqm.iter().cloned()),
+            _ => {}
+        }
+    }
+    Nl80211Event::CqmRssi(Nl80211CqmRssiEvent {
+        wiphy,
+        if_index,
+        mac,
+        events,
     })
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod channel;
 mod command;
 mod connect;
 mod connection;
+mod cqm;
 mod element;
 mod error;
 mod event;
@@ -18,6 +19,7 @@ mod handle;
 mod iface;
 mod key;
 mod key_request;
+mod mac;
 mod macros;
 mod message;
 mod mlo;
@@ -66,6 +68,10 @@ pub use self::connection::new_connection_with_socket;
 pub use self::connection::new_multicast_connection;
 pub use self::connection::new_multicast_connection_with_socket;
 pub use self::connection::Nl80211MulticastGroup;
+pub use self::cqm::{
+    Nl80211Cqm, Nl80211CqmAttr, Nl80211CqmRequest, Nl80211CqmRssiEvent,
+    Nl80211CqmRssiThresholdEvent,
+};
 pub use self::element::{
     Ieee80211AkmSuite, Ieee80211CipherSuite, Ieee80211Element,
     Ieee80211ElementCountryEnvironment, Ieee80211ElementCountryTriplet,

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+
+/// Length of an IEEE 802 MAC (Ethernet) address in bytes.
+pub(crate) const ETH_ALEN: usize = 6;

--- a/src/mlo.rs
+++ b/src/mlo.rs
@@ -6,8 +6,8 @@ use netlink_packet_core::{
 };
 
 use crate::attr::NL80211_ATTR_MAC;
+use crate::mac::ETH_ALEN;
 
-const ETH_ALEN: usize = 6;
 const NL80211_ATTR_MLO_LINK_ID: u16 = 313;
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/src/scan/bss_info.rs
+++ b/src/scan/bss_info.rs
@@ -38,6 +38,7 @@ use netlink_packet_core::{
 };
 
 use crate::bytes::{write_i32, write_u16, write_u32, write_u64};
+use crate::mac::ETH_ALEN;
 use crate::Ieee80211CapabilityInfo;
 
 bitflags::bitflags! {
@@ -72,8 +73,6 @@ impl Emitable for Nl80211BssUseFor {
         buffer.copy_from_slice(&self.bits().to_ne_bytes())
     }
 }
-
-const ETH_ALEN: usize = 6;
 
 const NL80211_BSS_BSSID: u16 = 1;
 const NL80211_BSS_FREQUENCY: u16 = 2;

--- a/src/scan/schedule.rs
+++ b/src/scan/schedule.rs
@@ -10,6 +10,7 @@ use netlink_packet_core::{
 };
 use netlink_packet_generic::GenlMessage;
 
+use crate::mac::ETH_ALEN;
 use crate::{
     bytes::{write_i32, write_u32},
     nl80211_execute, Nl80211Attr, Nl80211Command, Nl80211Error, Nl80211Handle,
@@ -81,8 +82,6 @@ impl Nl80211ScanScheduleStopRequest {
         nl80211_execute(&mut handle, nl80211_msg, flags).await
     }
 }
-
-const ETH_ALEN: usize = 6;
 
 const NL80211_SCHED_SCAN_MATCH_ATTR_SSID: u16 = 1;
 const NL80211_SCHED_SCAN_MATCH_ATTR_RSSI: u16 = 2;

--- a/src/station/get.rs
+++ b/src/station/get.rs
@@ -4,12 +4,11 @@ use futures::TryStream;
 use netlink_packet_core::{NLM_F_DUMP, NLM_F_REQUEST};
 use netlink_packet_generic::GenlMessage;
 
+use crate::mac::ETH_ALEN;
 use crate::{
     nl80211_execute, Nl80211Attr, Nl80211Command, Nl80211Error, Nl80211Handle,
     Nl80211Message,
 };
-
-const ETH_ALEN: usize = 6;
 
 pub struct Nl80211StationGetRequest {
     handle: Nl80211Handle,

--- a/src/tests/cqm.rs
+++ b/src/tests/cqm.rs
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: MIT
+
+// Round-trip tests for the connection quality monitor attributes
+// (`NL80211_ATTR_CQM` and its nested sub-attributes), the
+// `NL80211_CMD_SET_CQM` request builder and the `NL80211_CMD_NOTIFY_CQM`
+// event.
+//
+// The `test_captured_*` blobs are full netlink messages captured on the
+// `nl0` nlmon netlink monitor (LINKTYPE_NETLINK) while shulid connected
+// to a mac80211_hwsim hostapd AP and armed the kernel connection quality
+// monitor; the `NL80211_ATTR_WIPHY`/`NL80211_ATTR_IFINDEX` values and the
+// dynamic nl80211 family id (0x2c) are those of the capture. The other
+// blobs are hand-built netlink attributes (length, type, value) padded to
+// the 4-byte netlink alignment, mirroring the kernel's `nla_put` wire
+// format.
+
+use genetlink::message::RawGenlMessage;
+use netlink_packet_core::{
+    Emitable, NetlinkMessage, NetlinkPayload, NlaBuffer, Parseable,
+};
+use netlink_packet_generic::GenlMessage;
+
+use crate::{
+    Nl80211Attr, Nl80211Command, Nl80211Cqm, Nl80211CqmAttr,
+    Nl80211CqmRssiThresholdEvent, Nl80211Event, Nl80211Message,
+};
+
+fn assert_roundtrip(expected: Nl80211Attr, raw: Vec<u8>) {
+    assert_eq!(
+        expected,
+        Nl80211Attr::parse(&NlaBuffer::new_checked(&raw).unwrap()).unwrap()
+    );
+    let mut buf = vec![0; expected.buffer_len()];
+    expected.emit(&mut buf);
+    assert_eq!(buf, raw);
+}
+
+// NL80211_ATTR_CQM (94), a nested attribute holding
+// NL80211_ATTR_CQM_RSSI_THOLD (1, s32) and NL80211_ATTR_CQM_RSSI_HYST
+// (2, u32).
+#[test]
+fn test_cqm_threshold_roundtrip() {
+    // Outer attribute: 4-byte header + 16-byte payload (two 8-byte
+    // sub-attributes: RSSI_THOLD=-70 (0xffffffba), RSSI_HYST=5).
+    let raw = vec![
+        0x14, 0x00, 0x5e, 0x80, 0x08, 0x00, 0x01, 0x00, 0xba, 0xff, 0xff, 0xff,
+        0x08, 0x00, 0x02, 0x00, 0x05, 0x00, 0x00, 0x00,
+    ];
+    assert_roundtrip(
+        Nl80211Attr::Cqm(vec![
+            Nl80211CqmAttr::RssiThold(-70),
+            Nl80211CqmAttr::RssiHyst(5),
+        ]),
+        raw,
+    );
+}
+
+// NL80211_ATTR_CQM (94) as carried by a `NL80211_CMD_NOTIFY_CQM` event:
+// NL80211_ATTR_CQM_RSSI_THRESHOLD_EVENT (3, u32) + NL80211_ATTR_CQM_RSSI_LEVEL
+// (9, s32).
+#[test]
+fn test_cqm_event_roundtrip() {
+    // Nested payload: THRESHOLD_EVENT=LOW (0), RSSI_LEVEL=-72 (0xffffffb8).
+    let raw = vec![
+        0x14, 0x00, 0x5e, 0x80, 0x08, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x08, 0x00, 0x09, 0x00, 0xb8, 0xff, 0xff, 0xff,
+    ];
+    assert_roundtrip(
+        Nl80211Attr::Cqm(vec![
+            Nl80211CqmAttr::RssiThresholdEvent(
+                Nl80211CqmRssiThresholdEvent::Low,
+            ),
+            Nl80211CqmAttr::RssiLevel(-72),
+        ]),
+        raw,
+    );
+}
+
+// The SET_CQM request builder must attach the CQM attribute to the
+// interface.
+#[test]
+fn test_cqm_request_builder() {
+    let attrs = Nl80211Cqm::new(7).rssi_thold(-70).rssi_hyst(5).build();
+    assert_eq!(
+        attrs,
+        vec![
+            Nl80211Attr::IfIndex(7),
+            Nl80211Attr::Cqm(vec![
+                Nl80211CqmAttr::RssiThold(-70),
+                Nl80211CqmAttr::RssiHyst(5),
+            ]),
+        ]
+    );
+}
+
+// `NL80211_CMD_SET_CQM` (63) request captured on the `nl0` nlmon netlink
+// monitor while shulid connected to a mac80211_hwsim hostapd AP (fixed
+// -30 dBm signal) and armed the connection quality monitor at
+// -10 dBm / 5 dBm hysteresis: nl80211 family id 0x2c, ifindex 574.
+// Deserialize the full message and verify the command + attributes; the
+// builder must reproduce exactly the captured attribute bytes.
+#[test]
+fn test_captured_set_cqm_message() {
+    let raw = vec![
+        0x30, 0x00, 0x00, 0x00, 0x2c, 0x00, 0x05, 0x00, 0x10, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x3f, 0x01, 0x00, 0x00, 0x08, 0x00, 0x03, 0x00,
+        0x3e, 0x02, 0x00, 0x00, 0x14, 0x00, 0x5e, 0x80, 0x08, 0x00, 0x01, 0x00,
+        0xf6, 0xff, 0xff, 0xff, 0x08, 0x00, 0x02, 0x00, 0x05, 0x00, 0x00, 0x00,
+    ];
+    let msg = parse_request(&raw);
+    assert_eq!(Nl80211Command::SetCqm, msg.cmd);
+    assert_eq!(
+        vec![
+            Nl80211Attr::IfIndex(574),
+            Nl80211Attr::Cqm(vec![
+                Nl80211CqmAttr::RssiThold(-10),
+                Nl80211CqmAttr::RssiHyst(5),
+            ]),
+        ],
+        msg.attributes
+    );
+    let attributes = Nl80211Cqm::new(574).rssi_thold(-10).rssi_hyst(5).build();
+    assert_eq!(&raw[20..], emit_attributes(attributes));
+}
+
+// `NL80211_CMD_NOTIFY_CQM` (64) event captured on the same run: the
+// kernel reported the -30 dBm signal dropped below the -10 dBm roam
+// threshold (LOW crossing, `NL80211_ATTR_CQM_RSSI_LEVEL` = -30). The
+// event rides the `config` multicast group with the WIPHY (315) /
+// IFINDEX (574) of the capture; the peer MAC is not included.
+#[test]
+fn test_captured_notify_cqm_event() {
+    let raw = vec![
+        0x38, 0x00, 0x00, 0x00, 0x2c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x40, 0x01, 0x00, 0x00, 0x08, 0x00, 0x01, 0x00,
+        0x3b, 0x01, 0x00, 0x00, 0x08, 0x00, 0x03, 0x00, 0x3e, 0x02, 0x00, 0x00,
+        0x14, 0x00, 0x5e, 0x00, 0x08, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x08, 0x00, 0x09, 0x00, 0xe2, 0xff, 0xff, 0xff,
+    ];
+    match parse_event(&raw).expect("parse event") {
+        Nl80211Event::CqmRssi(ev) => {
+            assert_eq!(315, ev.wiphy);
+            assert_eq!(574, ev.if_index);
+            assert_eq!(None, ev.mac);
+            assert_eq!(
+                vec![
+                    Nl80211CqmAttr::RssiThresholdEvent(
+                        Nl80211CqmRssiThresholdEvent::Low,
+                    ),
+                    Nl80211CqmAttr::RssiLevel(-30),
+                ],
+                ev.events
+            );
+        }
+        other => panic!("unexpected event: {other:?}"),
+    }
+}
+
+fn parse_request(raw: &[u8]) -> Nl80211Message {
+    let msg = NetlinkMessage::<GenlMessage<Nl80211Message>>::deserialize(raw)
+        .expect("deserialize SET_CQM request");
+    match msg.payload {
+        NetlinkPayload::InnerMessage(m) => m.payload,
+        other => panic!("unexpected payload: {other:?}"),
+    }
+}
+
+fn parse_event(raw: &[u8]) -> Option<Nl80211Event> {
+    let msg =
+        NetlinkMessage::<RawGenlMessage>::deserialize(raw).expect("event");
+    Nl80211Event::parse(msg)
+}
+
+fn emit_attributes(attributes: Vec<Nl80211Attr>) -> Vec<u8> {
+    let msg = Nl80211Message {
+        cmd: Nl80211Command::SetCqm,
+        attributes,
+    };
+    let mut buf = vec![0u8; msg.buffer_len()];
+    msg.emit(&mut buf);
+    buf
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -3,6 +3,7 @@
 mod auth_assoc;
 mod connect;
 mod control_port_frame;
+mod cqm;
 mod disconnect;
 mod event;
 mod key;


### PR DESCRIPTION
Introduced support for the kernel connection quality monitor (CQM),
used by station signal-triggered roaming:

- New nested NL80211_ATTR_CQM attribute with the RSSI threshold,
  hysteresis, threshold-event and level sub-attributes.
- Nl80211Cqm builder and set_cqm() on Nl80211ConnectionHandle to arm
  NL80211_CMD_SET_CQM on an interface.
- NL80211_CMD_NOTIFY_CQM events parsed into
  Nl80211Event::CqmRssi(Nl80211CqmRssiEvent), carrying the reporting
  WIPHY/IFINDEX, the peer MAC and the full CQM sub-attribute list.

Unified the duplicated per-file ETH_ALEN constants into src/mac.rs.

Unit tests included: attribute round-trips plus nlmon-captured SET_CQM
request and NOTIFY_CQM event messages.