### PR TITLE
New release 0.7.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,14 @@
 # Changelog
+## [0.7.0] - 2026-08-18
+### Breaking changes
+ - Use latest rust-netlink crates. (69931a9)
+
+### New features
+ - N/A
+
+### Bug fixes
+ - N/A
+
 ## [0.6.0] - 2026-08-16
 ### Breaking changes
  - Rename IEEE 802.11 types to Ieee80211 prefix and merge duplicate

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # The crate name `nl80211` is occupied
 name = "wl-nl80211"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Gris Ge <cnfourt@gmail.com>"]
 license = "MIT"
 edition = "2021"


### PR DESCRIPTION
=== Breaking changes
 - Use latest rust-netlink crates. (69931a9)

=== New features
 - N/A

=== Bug fixes
 - N/A