### PR TITLE
wiphy: Allow filter on `NL80211_CMD_GET_WIPHY`

### DIFF
--- a/src/wiphy/get.rs
+++ b/src/wiphy/get.rs
@@ -11,22 +11,59 @@ use crate::{
 
 pub struct Nl80211WiphyGetRequest {
     handle: Nl80211Handle,
+    filter: Option<Nl80211Attr>,
 }
 
 impl Nl80211WiphyGetRequest {
     pub(crate) fn new(handle: Nl80211Handle) -> Self {
-        Nl80211WiphyGetRequest { handle }
+        Nl80211WiphyGetRequest {
+            handle,
+            filter: None,
+        }
+    }
+
+    /// Filter the dump to the wiphy with this wiphy index
+    /// (`NL80211_ATTR_WIPHY`).
+    ///
+    /// Replaces any previously set filter.
+    pub fn wiphy_index(mut self, wiphy_index: u32) -> Self {
+        self.filter = Some(Nl80211Attr::Wiphy(wiphy_index));
+        self
+    }
+
+    /// Filter the dump to the wiphy owning the interface with this interface
+    /// index (`NL80211_ATTR_IFINDEX`).
+    ///
+    /// Replaces any previously set filter.
+    pub fn if_index(mut self, if_index: u32) -> Self {
+        self.filter = Some(Nl80211Attr::IfIndex(if_index));
+        self
+    }
+
+    /// Filter the dump to the wiphy owning the wireless device with this wdev
+    /// identifier (`NL80211_ATTR_WDEV`).
+    ///
+    /// Replaces any previously set filter.
+    pub fn wdev(mut self, wdev: u64) -> Self {
+        self.filter = Some(Nl80211Attr::Wdev(wdev));
+        self
     }
 
     pub async fn execute(
         self,
     ) -> impl TryStream<Ok = GenlMessage<Nl80211Message>, Error = Nl80211Error>
     {
-        let Nl80211WiphyGetRequest { mut handle } = self;
+        let Nl80211WiphyGetRequest { mut handle, filter } = self;
+
+        let mut attributes = vec![Nl80211Attr::SplitWiphyDump];
+
+        if let Some(f) = filter {
+            attributes.push(f);
+        }
 
         let nl80211_msg = Nl80211Message {
             cmd: Nl80211Command::GetWiphy,
-            attributes: vec![Nl80211Attr::SplitWiphyDump],
+            attributes,
         };
 
         let flags = NLM_F_REQUEST | NLM_F_DUMP;

--- a/src/wiphy/handle.rs
+++ b/src/wiphy/handle.rs
@@ -14,8 +14,12 @@ impl Nl80211WiphyHandle {
         Nl80211WiphyHandle(handle)
     }
 
-    /// Retrieve the wireless interfaces
-    /// (equivalent to `iw phy`)
+    /// Retrieve the wireless interfaces (equivalent to `iw phy`).
+    ///
+    /// Without a filter this dumps all wiphys. Use
+    /// [`Nl80211WiphyGetRequest::wiphy_index`] or
+    /// [`Nl80211WiphyGetRequest::if_index`] to request information for a
+    /// single wiphy.
     pub fn get(&mut self) -> Nl80211WiphyGetRequest {
         Nl80211WiphyGetRequest::new(self.0.clone())
     }


### PR DESCRIPTION
Exmaple:

```rust
  handle
      .wireless_physic()
      .get()
      .if_index(5)
      .execute()
```

Or `.wiphy_index(0)` or `.wdev(0)`.