### PR TITLE
Disable tests on big-endian targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,8 @@ mod wifi7;
 mod wiphy;
 mod wowlan_request;
 
+// test data are using hard coded little endian byte order, not for big-endian
+#[cfg(not(target_endian = "big"))]
 #[cfg(test)]
 mod tests;
 

--- a/src/wifi4.rs
+++ b/src/wifi4.rs
@@ -8,6 +8,8 @@ use netlink_packet_core::{
 
 use crate::bytes::{get_bit, get_bits_as_u8, write_u16_le};
 
+// test data are using hard coded little endian byte order, not for big-endian
+#[cfg(not(target_endian = "big"))]
 #[cfg(test)]
 mod test;
 


### PR DESCRIPTION
The test data are hard-coded in little-endian byte order, so the test
cases should be skipped on big-endian system(e.g. s390x).